### PR TITLE
chore(sync): merge develop into bugfix/72-ci-permissions-for-hierarchy-validation

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
+      issues: write
       pull-requests: write
 
     steps:
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -8,7 +8,11 @@ jobs:
   validate-issue-hierarchy:
     name: Validate Issue Hierarchy
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -88,7 +92,10 @@ jobs:
   validate-commit-messages:
     name: Validate Commit Messages
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced Making Changes section with project board workflow steps
 
 ### Fixed
-- Added explicit `permissions` blocks to `validate-issue-hierarchy` and `validate-commit-messages` CI jobs to ensure `GITHUB_TOKEN` always has `issues: read` and `pull-requests: write` scopes — resolves false-negative hierarchy validation failures (#72)
+- Add explicit `permissions` blocks to `validate-issue-hierarchy` and `validate-commit-messages` CI jobs to ensure `GITHUB_TOKEN` always has `issues: write` and `pull-requests: write` scopes — resolves false-negative hierarchy validation failures (#72)
 
 ## [Unreleased - Previously]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated docs/processes/release-process.md with Project 1 details and workflow states
 - Enhanced Making Changes section with project board workflow steps
 
+### Fixed
+- Added explicit `permissions` blocks to `validate-issue-hierarchy` and `validate-commit-messages` CI jobs to ensure `GITHUB_TOKEN` always has `issues: read` and `pull-requests: write` scopes — resolves false-negative hierarchy validation failures (#72)
+
 ## [Unreleased - Previously]
 
 ### Added

--- a/scripts/validate-issue-hierarchy.js
+++ b/scripts/validate-issue-hierarchy.js
@@ -92,7 +92,7 @@ async function getIssue(issueNumber) {
     const issue = response?.data?.repository?.issue;
 
     if (!issue) {
-      throw new Error(`Issue #${issueNumber} not found`);
+      return null;
     }
 
     return {
@@ -181,6 +181,12 @@ async function validateIssues(issueNumbers) {
     try {
       console.log(`Checking issue #${issueNumber}...`);
       const issue = await getIssue(issueNumber);
+
+      if (!issue) {
+        console.log(`  ⚠️  #${issueNumber} is not an issue (may be a pull request) — skipping`);
+        results.push({ issue: { number: issueNumber }, valid: true, errors: [], warnings: ['Not an issue — skipped'] });
+        continue;
+      }
       
       // Check if issue is closed
       if (issue.state === 'closed') {


### PR DESCRIPTION
This maintainer-created PR merges the latest `develop` into `bugfix/72-ci-permissions-for-hierarchy-validation` and resolves trivial conflicts automatically. Please review and merge.