### PR TITLE
fix(events): Phase 5B — restore soft-deleted events and audit event writes #216 #218

### DIFF
--- a/backend/src/controllers/event-controller.ts
+++ b/backend/src/controllers/event-controller.ts
@@ -14,6 +14,22 @@ export interface EventData {
   status: 'Draft' | 'Active' | 'Completed';
 }
 
+interface AuthRequest extends Request {
+  user?: { id: number; email: string; role_id: number };
+}
+
+async function recordEventAudit(
+  db: ReturnType<typeof getDatabase>,
+  req: AuthRequest,
+  action: string,
+  description: string,
+): Promise<void> {
+  await db.run(
+    'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+    [req.user?.id ?? null, req.user?.email ?? null, action, description, req.ip ?? null],
+  );
+}
+
 /**
  * Get all events
  */
@@ -24,6 +40,7 @@ export async function getAllEvents(req: Request, res: Response): Promise<void> {
       SELECT e.*, u.display_name as created_by_name
       FROM events e
       LEFT JOIN users u ON e.created_by = u.id
+      WHERE e.deleted_at IS NULL
       ORDER BY e.date DESC
     `);
     
@@ -46,7 +63,7 @@ export async function getEventById(req: Request, res: Response): Promise<void> {
       SELECT e.*, u.display_name as created_by_name
       FROM events e
       LEFT JOIN users u ON e.created_by = u.id
-      WHERE e.id = ?
+      WHERE e.id = ? AND e.deleted_at IS NULL
     `, [id]);
     
     if (!event) {
@@ -67,7 +84,9 @@ export async function getEventById(req: Request, res: Response): Promise<void> {
 export async function createEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
+    const userEmail = authReq.user?.email;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
@@ -94,6 +113,10 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
     `, [title, date, location, description || '', status || 'Draft', userId]);
     
     const newEvent = await db.get('SELECT * FROM events WHERE id = ?', [result.lastID]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, userEmail ?? null, 'event.created', `Created event #${result.lastID}: ${title}`, authReq.ip ?? null],
+    );
     
     res.status(201).json(newEvent);
   } catch (error) {
@@ -109,7 +132,8 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
     const { id } = req.params;
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
@@ -119,9 +143,14 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     const { title, date, location, description, status }: EventData = req.body;
     
     // Check if event exists
-    const existingEvent = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    const existingEvent = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NULL', [id]);
     if (!existingEvent) {
       res.status(404).json({ error: 'Event not found' });
+      return;
+    }
+
+    if (Number(existingEvent.created_by) !== Number(userId) && authReq.user?.role_id !== 3) {
+      res.status(403).json({ error: 'Not authorised to edit this event.' });
       return;
     }
     
@@ -145,6 +174,10 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     ]);
     
     const updatedEvent = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, authReq.user?.email ?? null, 'event.updated', `Updated event #${id}: ${updatedEvent?.title ?? existingEvent.title}`, authReq.ip ?? null],
+    );
     
     res.json(updatedEvent);
   } catch (error) {
@@ -160,24 +193,73 @@ export async function deleteEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
     const { id } = req.params;
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
       return;
     }
     
-    const event = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    const event = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NULL', [id]);
     if (!event) {
       res.status(404).json({ error: 'Event not found' });
       return;
     }
     
-    await db.run('DELETE FROM events WHERE id = ?', [id]);
+    if (Number(event.created_by) !== Number(userId) && authReq.user?.role_id !== 3) {
+      res.status(403).json({ error: 'Not authorised to delete this event.' });
+      return;
+    }
+
+    await db.run('UPDATE events SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, authReq.user?.email ?? null, 'event.deleted', `Soft-deleted event #${id}: ${event.title}`, authReq.ip ?? null],
+    );
     
     res.json({ message: 'Event deleted successfully' });
   } catch (error) {
     console.error('Error deleting event:', error);
     res.status(500).json({ error: 'Failed to delete event' });
+  }
+}
+
+/**
+ * Restore a soft-deleted event
+ */
+export async function restoreEvent(req: Request, res: Response): Promise<void> {
+  try {
+    const db = getDatabase();
+    const { id } = req.params;
+    const authReq = req as AuthRequest;
+    const user = authReq.user;
+
+    if (!user) {
+      res.status(401).json({ error: 'User not authenticated' });
+      return;
+    }
+
+    if (user.role_id !== 3) {
+      res.status(403).json({ error: 'Only admins can restore events' });
+      return;
+    }
+
+    const event = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NOT NULL', [id]);
+    if (!event) {
+      res.status(404).json({ error: 'Event not found' });
+      return;
+    }
+
+    await db.run('UPDATE events SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [user.id, user.email, 'event.restored', `Restored event #${id}: ${event.title}`, authReq.ip ?? null],
+    );
+
+    res.json({ message: 'Event restored successfully' });
+  } catch (error) {
+    console.error('Error restoring event:', error);
+    res.status(500).json({ error: 'Failed to restore event' });
   }
 }

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -279,6 +279,7 @@ async function runMigrations(db: DbWrapper): Promise<void> {
       created_by INTEGER NOT NULL,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      deleted_at TIMESTAMP,
       FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     )
   `);

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -122,6 +122,7 @@ router.get('/events/:id', authenticateToken, eventController.getEventById);
 router.post('/events', authenticateToken, eventController.createEvent);
 router.put('/events/:id', authenticateToken, eventController.updateEvent);
 router.delete('/events/:id', authenticateToken, eventController.deleteEvent);
+router.post('/events/:id/restore', authenticateToken, eventController.restoreEvent);
 
 // ============ TASK ROUTES ============
 router.get('/tasks', authenticateToken, taskController.getAllTasks);


### PR DESCRIPTION
## Phase 5B — Event Safety

### Completed Stories
- Closes #216 (Implement Event Soft-Delete and Filtering)
- Closes #218 (Event Ownership & Authorization)
- Parent theme: #196 (Event Hub)

### What Was Developed

**backend/src/db/database.ts**
- Added deleted_at to the events table migration so soft-delete is supported at the schema level

**backend/src/controllers/event-controller.ts**
- list/get now exclude deleted events
- update/delete now enforce owner/admin authorization
- delete performs soft-delete instead of hard delete
- restore endpoint added for admins
- audit_log entries recorded for create/update/delete/restore actions

**backend/src/routes/api-routes.ts**
- Wired POST /api/events/:id/restore to the event controller

### Acceptance Criteria Coverage
- ✅ Deleted events are excluded from event lists and lookups
- ✅ Admin restore endpoint exists for soft-deleted events
- ✅ Ownership/admin checks enforced on event mutations
- ✅ Audit logs written for event create/update/delete/restore

### Notes
- Soft-delete is schema-backed via deleted_at
- Restore is admin-only in this implementation
- Audit log entries include user identity and IP when available