### PR TITLE
feat(phase5c): RSVP and task enhancements

### DIFF
--- a/backend/src/controllers/event-controller.ts
+++ b/backend/src/controllers/event-controller.ts
@@ -11,6 +11,7 @@ export interface EventData {
   date: string;
   location: string;
   description?: string;
+  capacity?: number | null;
   status: 'Draft' | 'Active' | 'Completed';
 }
 
@@ -71,7 +72,32 @@ export async function getEventById(req: Request, res: Response): Promise<void> {
       return;
     }
     
-    res.json(event);
+    const tasks = await db.all(
+      `SELECT t.*, COALESCE(u.display_name, t.assignee_name) AS assignee_name
+       FROM tasks t
+       LEFT JOIN users u ON t.assigned_user_id = u.id
+       WHERE t.event_id = ?
+       ORDER BY t.due_date ASC, t.priority ASC`,
+      [id],
+    );
+    const rsvps = await db.all('SELECT * FROM rsvps WHERE event_id = ? ORDER BY created_at DESC', [id]);
+    const members = await db.all(
+      `SELECT em.user_id, em.role, em.joined_at, u.display_name, u.email
+       FROM event_members em
+       JOIN users u ON u.id = em.user_id
+       WHERE em.event_id = ? AND u.deleted_at IS NULL
+       ORDER BY em.joined_at DESC`,
+      [id],
+    );
+    const availableUsers = await db.all(
+      `SELECT u.id AS user_id, u.display_name, u.email, r.name AS role_name
+       FROM users u
+       LEFT JOIN roles r ON r.id = u.role_id
+       WHERE u.deleted_at IS NULL
+       ORDER BY u.display_name ASC`,
+    );
+
+    res.json({ event, tasks, rsvps, members, availableUsers });
   } catch (error) {
     console.error('Error fetching event:', error);
     res.status(500).json({ error: 'Failed to fetch event' });
@@ -93,7 +119,7 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
       return;
     }
     
-    const { title, date, location, description, status }: EventData = req.body;
+    const { title, date, location, description, capacity, status }: EventData = req.body;
     
     // Validation
     if (!title || !date || !location) {
@@ -107,10 +133,10 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
     }
     
     const result = await db.run(`
-      INSERT INTO events (title, date, location, description, status, created_by)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO events (title, date, location, description, capacity, status, created_by)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       RETURNING id
-    `, [title, date, location, description || '', status || 'Draft', userId]);
+    `, [title, date, location, description || '', capacity ?? null, status || 'Draft', userId]);
     
     const newEvent = await db.get('SELECT * FROM events WHERE id = ?', [result.lastID]);
     await db.run(
@@ -140,7 +166,7 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
       return;
     }
     
-    const { title, date, location, description, status }: EventData = req.body;
+    const { title, date, location, description, capacity, status }: EventData = req.body;
     
     // Check if event exists
     const existingEvent = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NULL', [id]);
@@ -162,13 +188,14 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     
     await db.run(`
       UPDATE events 
-      SET title = ?, date = ?, location = ?, description = ?, status = ?, updated_at = CURRENT_TIMESTAMP
+      SET title = ?, date = ?, location = ?, description = ?, capacity = ?, status = ?, updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
     `, [
       title || existingEvent.title,
       date || existingEvent.date,
       location || existingEvent.location,
       description !== undefined ? description : existingEvent.description,
+      capacity !== undefined ? capacity : existingEvent.capacity,
       status || existingEvent.status,
       id
     ]);

--- a/backend/src/controllers/event-controller.ts
+++ b/backend/src/controllers/event-controller.ts
@@ -14,6 +14,22 @@ export interface EventData {
   status: 'Draft' | 'Active' | 'Completed';
 }
 
+interface AuthRequest extends Request {
+  user?: { id: number; email: string; role_id: number };
+}
+
+async function recordEventAudit(
+  db: ReturnType<typeof getDatabase>,
+  req: AuthRequest,
+  action: string,
+  description: string,
+): Promise<void> {
+  await db.run(
+    'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+    [req.user?.id ?? null, req.user?.email ?? null, action, description, req.ip ?? null],
+  );
+}
+
 /**
  * Get all events
  */
@@ -24,6 +40,7 @@ export async function getAllEvents(req: Request, res: Response): Promise<void> {
       SELECT e.*, u.display_name as created_by_name
       FROM events e
       LEFT JOIN users u ON e.created_by = u.id
+      WHERE e.deleted_at IS NULL
       ORDER BY e.date DESC
     `);
     
@@ -46,7 +63,7 @@ export async function getEventById(req: Request, res: Response): Promise<void> {
       SELECT e.*, u.display_name as created_by_name
       FROM events e
       LEFT JOIN users u ON e.created_by = u.id
-      WHERE e.id = ?
+      WHERE e.id = ? AND e.deleted_at IS NULL
     `, [id]);
     
     if (!event) {
@@ -67,7 +84,9 @@ export async function getEventById(req: Request, res: Response): Promise<void> {
 export async function createEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
+    const userEmail = authReq.user?.email;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
@@ -94,6 +113,10 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
     `, [title, date, location, description || '', status || 'Draft', userId]);
     
     const newEvent = await db.get('SELECT * FROM events WHERE id = ?', [result.lastID]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, userEmail ?? null, 'event.created', `Created event #${result.lastID}: ${title}`, authReq.ip ?? null],
+    );
     
     res.status(201).json(newEvent);
   } catch (error) {
@@ -109,7 +132,8 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
     const { id } = req.params;
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
@@ -119,9 +143,14 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     const { title, date, location, description, status }: EventData = req.body;
     
     // Check if event exists
-    const existingEvent = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    const existingEvent = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NULL', [id]);
     if (!existingEvent) {
       res.status(404).json({ error: 'Event not found' });
+      return;
+    }
+
+    if (Number(existingEvent.created_by) !== Number(userId) && authReq.user?.role_id !== 3) {
+      res.status(403).json({ error: 'Not authorised to edit this event.' });
       return;
     }
     
@@ -145,6 +174,10 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     ]);
     
     const updatedEvent = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, authReq.user?.email ?? null, 'event.updated', `Updated event #${id}: ${updatedEvent?.title ?? existingEvent.title}`, authReq.ip ?? null],
+    );
     
     res.json(updatedEvent);
   } catch (error) {
@@ -160,24 +193,73 @@ export async function deleteEvent(req: Request, res: Response): Promise<void> {
   try {
     const db = getDatabase();
     const { id } = req.params;
-    const userId = (req as any).user?.id;
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id;
     
     if (!userId) {
       res.status(401).json({ error: 'User not authenticated' });
       return;
     }
     
-    const event = await db.get('SELECT * FROM events WHERE id = ?', [id]);
+    const event = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NULL', [id]);
     if (!event) {
       res.status(404).json({ error: 'Event not found' });
       return;
     }
     
-    await db.run('DELETE FROM events WHERE id = ?', [id]);
+    if (Number(event.created_by) !== Number(userId) && authReq.user?.role_id !== 3) {
+      res.status(403).json({ error: 'Not authorised to delete this event.' });
+      return;
+    }
+
+    await db.run('UPDATE events SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [userId, authReq.user?.email ?? null, 'event.deleted', `Soft-deleted event #${id}: ${event.title}`, authReq.ip ?? null],
+    );
     
     res.json({ message: 'Event deleted successfully' });
   } catch (error) {
     console.error('Error deleting event:', error);
     res.status(500).json({ error: 'Failed to delete event' });
+  }
+}
+
+/**
+ * Restore a soft-deleted event
+ */
+export async function restoreEvent(req: Request, res: Response): Promise<void> {
+  try {
+    const db = getDatabase();
+    const { id } = req.params;
+    const authReq = req as AuthRequest;
+    const user = authReq.user;
+
+    if (!user) {
+      res.status(401).json({ error: 'User not authenticated' });
+      return;
+    }
+
+    if (user.role_id !== 3) {
+      res.status(403).json({ error: 'Only admins can restore events' });
+      return;
+    }
+
+    const event = await db.get('SELECT * FROM events WHERE id = ? AND deleted_at IS NOT NULL', [id]);
+    if (!event) {
+      res.status(404).json({ error: 'Event not found' });
+      return;
+    }
+
+    await db.run('UPDATE events SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+    await db.run(
+      'INSERT INTO audit_log (user_id, email, action, description, ip_address) VALUES (?, ?, ?, ?, ?)',
+      [user.id, user.email, 'event.restored', `Restored event #${id}: ${event.title}`, authReq.ip ?? null],
+    );
+
+    res.json({ message: 'Event restored successfully' });
+  } catch (error) {
+    console.error('Error restoring event:', error);
+    res.status(500).json({ error: 'Failed to restore event' });
   }
 }

--- a/backend/src/controllers/event-members-controller.ts
+++ b/backend/src/controllers/event-members-controller.ts
@@ -1,0 +1,77 @@
+import { Request, Response } from 'express';
+import { getDatabase } from '../db/database.js';
+
+interface AuthRequest extends Request {
+  user?: { id: number; email: string; role_id: number };
+}
+
+/** GET /api/events/:eventId/members */
+export async function listMembers(req: Request, res: Response): Promise<Response> {
+  const db = getDatabase();
+  const { eventId } = req.params;
+  const members = await db.all(
+    `SELECT em.user_id, em.role, em.joined_at, u.display_name, u.email
+     FROM event_members em
+     JOIN users u ON u.id = em.user_id
+     WHERE em.event_id = ? AND u.deleted_at IS NULL
+     ORDER BY em.joined_at DESC`,
+    [eventId],
+  );
+
+  const availableUsers = await db.all(
+    `SELECT u.id AS user_id, u.display_name, u.email, r.name AS role_name
+     FROM users u
+     LEFT JOIN roles r ON r.id = u.role_id
+     WHERE u.deleted_at IS NULL
+     ORDER BY u.display_name ASC`,
+  );
+
+  return res.json({ members, availableUsers });
+}
+
+/** POST /api/events/:eventId/members */
+export async function addMember(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { eventId } = req.params;
+  const { user_id, role } = req.body as { user_id?: number; role?: string };
+
+  if (!authReq.user) return res.status(401).json({ error: 'Authentication required.' });
+  const event = await db.get<{ created_by: number }>('SELECT created_by FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
+  if (!event) return res.status(404).json({ error: 'Event not found.' });
+  if (authReq.user.role_id < 3 && event.created_by !== authReq.user.id) {
+    return res.status(403).json({ error: 'Not authorised to manage members for this event.' });
+  }
+
+  const numericUserId = Number(user_id);
+  if (!Number.isInteger(numericUserId)) return res.status(400).json({ error: 'user_id is required.' });
+
+  const user = await db.get('SELECT id FROM users WHERE id = ? AND deleted_at IS NULL', [numericUserId]);
+  if (!user) return res.status(404).json({ error: 'User not found.' });
+
+  await db.run(
+    `INSERT INTO event_members (event_id, user_id, role)
+     VALUES (?, ?, ?)
+     ON CONFLICT (event_id, user_id) DO UPDATE SET role = EXCLUDED.role`,
+    [eventId, numericUserId, role || 'Member'],
+  );
+
+  return res.status(201).json({ message: 'Member added.' });
+}
+
+/** DELETE /api/events/:eventId/members/:userId */
+export async function removeMember(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { eventId, userId } = req.params;
+
+  if (!authReq.user) return res.status(401).json({ error: 'Authentication required.' });
+  const event = await db.get<{ created_by: number }>('SELECT created_by FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
+  if (!event) return res.status(404).json({ error: 'Event not found.' });
+  if (authReq.user.role_id < 3 && event.created_by !== authReq.user.id) {
+    return res.status(403).json({ error: 'Not authorised to manage members for this event.' });
+  }
+
+  await db.run('DELETE FROM event_members WHERE event_id = ? AND user_id = ?', [eventId, userId]);
+  return res.json({ message: 'Member removed.' });
+}

--- a/backend/src/controllers/rsvps-controller.ts
+++ b/backend/src/controllers/rsvps-controller.ts
@@ -5,43 +5,112 @@ interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
 }
 
+function parseGuests(value: unknown): number {
+  if (value === undefined || value === null || value === '') return 1;
+  const guests = Number(value);
+  if (!Number.isInteger(guests) || guests < 1) {
+    throw new Error('Guest count must be a positive integer.');
+  }
+  return guests;
+}
+
+function isGoing(status?: string): boolean {
+  return status === 'Going';
+}
+
+async function getEventCapacity(db: ReturnType<typeof getDatabase>, eventId: string): Promise<number | null> {
+  const event = await db.get<{ capacity: number | null }>('SELECT capacity FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
+  return event?.capacity ?? null;
+}
+
+async function getGoingGuestsTotal(db: ReturnType<typeof getDatabase>, eventId: string, excludeRsvpId?: string): Promise<number> {
+  const rows = await db.all<{ total_guests: number }>(
+    `SELECT COALESCE(SUM(guests), 0) AS total_guests
+     FROM rsvps
+     WHERE event_id = ? AND status = 'Going'${excludeRsvpId ? ' AND id <> ?' : ''}`,
+    excludeRsvpId ? [eventId, excludeRsvpId] : [eventId],
+  );
+  return rows[0]?.total_guests ?? 0;
+}
+
+function csvEscape(value: unknown): string {
+  const text = String(value ?? '');
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
 /** GET /api/events/:eventId/rsvps */
 export async function listRsvps(req: Request, res: Response): Promise<Response> {
   const db = getDatabase();
   const { eventId } = req.params;
-  const rows = await db.all('SELECT * FROM rsvps WHERE event_id = ? ORDER BY created_at DESC', [eventId]);
+  const rows = await db.all(
+    'SELECT * FROM rsvps WHERE event_id = ? ORDER BY created_at DESC',
+    [eventId],
+  );
   return res.json({ rsvps: rows });
+}
+
+/** GET /api/public/events/:eventId */
+export async function getPublicRsvpContext(req: Request, res: Response): Promise<Response> {
+  const db = getDatabase();
+  const { eventId } = req.params;
+  const event = await db.get<{ id: number; title: string; description: string | null; location: string | null; event_date: string; capacity: number | null }>(
+    'SELECT id, title, description, location, event_date, capacity FROM events WHERE id = ? AND deleted_at IS NULL',
+    [eventId],
+  );
+  if (!event) return res.status(404).json({ error: 'Event not found.' });
+
+  const goingGuests = await getGoingGuestsTotal(db, eventId);
+  const remainingCapacity = event.capacity === null ? null : Math.max(event.capacity - goingGuests, 0);
+
+  return res.json({ event, remainingCapacity });
 }
 
 /** POST /api/events/:eventId/rsvps  (public — no auth) */
 export async function createRsvp(req: Request, res: Response): Promise<Response> {
   const { eventId } = req.params;
-  const { name, email, status, notes } = req.body as {
+  const { name, email, status, notes, guests } = req.body as {
     name?: string;
     email?: string;
     status?: string;
     notes?: string;
+    guests?: number | string;
   };
 
   if (!name?.trim()) return res.status(400).json({ error: 'Name is required.' });
   if (!email?.trim()) return res.status(400).json({ error: 'Email is required.' });
 
+  let guestCount: number;
+  try {
+    guestCount = parseGuests(guests);
+  } catch (error) {
+    return res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid guest count.' });
+  }
+
   const db = getDatabase();
   const event = await db.get('SELECT id FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
   if (!event) return res.status(404).json({ error: 'Event not found.' });
+
+  const capacity = await getEventCapacity(db, eventId);
+  if (capacity !== null && isGoing(status || 'Pending')) {
+    const currentGoing = await getGoingGuestsTotal(db, eventId);
+    if (currentGoing + guestCount > capacity) {
+      return res.status(409).json({ error: 'Event capacity exceeded.' });
+    }
+  }
 
   // Determine source based on whether request is authenticated
   const authReq = req as AuthRequest;
   const source = authReq.user ? 'internal' : 'public';
 
   const result = await db.run(
-    `INSERT INTO rsvps (event_id, name, email, status, notes, source)
-     VALUES (?, ?, ?, ?, ?, ?)
+    `INSERT INTO rsvps (event_id, name, email, guests, status, notes, source)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
      RETURNING id`,
     [
       eventId,
       name.trim(),
       email.trim().toLowerCase(),
+      guestCount,
       status || 'Pending',
       notes?.trim() || null,
       source,
@@ -60,13 +129,36 @@ export async function updateRsvp(req: Request, res: Response): Promise<Response>
   const rsvp = await db.get('SELECT * FROM rsvps WHERE id = ?', [id]);
   if (!rsvp) return res.status(404).json({ error: 'RSVP not found.' });
 
-  const { name, email, status, notes } = req.body as Record<string, string>;
+  const { name, email, status, notes, guests } = req.body as Record<string, string>;
   const fields: string[] = [];
-  const params: (string | null)[] = [];
+  const params: (string | number | null)[] = [];
+
+  let nextGuests = Number(rsvp.guests ?? 1);
+  let nextStatus = rsvp.status;
+  if (guests !== undefined) {
+    const parsed = parseGuests(guests);
+    nextGuests = parsed;
+    fields.push('guests = ?');
+    params.push(parsed);
+  }
+  if (status !== undefined) {
+    nextStatus = status;
+    fields.push('status = ?');
+    params.push(status);
+  }
+
+  if (isGoing(nextStatus)) {
+    const capacity = await getEventCapacity(db, String(rsvp.event_id));
+    if (capacity !== null) {
+      const currentGoing = await getGoingGuestsTotal(db, String(rsvp.event_id), String(id));
+      if (currentGoing + nextGuests > capacity) {
+        return res.status(409).json({ error: 'Event capacity exceeded.' });
+      }
+    }
+  }
 
   if (name !== undefined) { fields.push('name = ?'); params.push(name.trim()); }
   if (email !== undefined) { fields.push('email = ?'); params.push(email.trim().toLowerCase()); }
-  if (status !== undefined) { fields.push('status = ?'); params.push(status); }
   if (notes !== undefined) { fields.push('notes = ?'); params.push(notes.trim() || null); }
 
   if (fields.length === 0) return res.status(400).json({ error: 'No fields to update.' });
@@ -89,4 +181,51 @@ export async function deleteRsvp(req: Request, res: Response): Promise<Response>
 
   await db.run('DELETE FROM rsvps WHERE id = ?', [id]);
   return res.json({ message: 'RSVP deleted.' });
+}
+
+/** GET /api/events/:eventId/rsvps/export?format=csv */
+export async function exportRsvpsCsv(req: Request, res: Response): Promise<Response> {
+  const db = getDatabase();
+  const { eventId } = req.params;
+  const { format } = req.query as { format?: string };
+
+  if (format && format !== 'csv') {
+    return res.status(400).json({ error: 'Unsupported export format.' });
+  }
+
+  const authReq = req as AuthRequest;
+  if (!authReq.user) {
+    return res.status(401).json({ error: 'Authentication required.' });
+  }
+
+  const event = await db.get<{ created_by: number }>('SELECT created_by FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
+  if (!event) return res.status(404).json({ error: 'Event not found.' });
+  if (authReq.user.role_id < 3 && event.created_by !== authReq.user.id) {
+    return res.status(403).json({ error: 'Not authorised to export this event.' });
+  }
+
+  const rows = await db.all<{
+    name: string;
+    email: string;
+    status: string;
+    guests: number;
+    notes: string | null;
+    created_at: string;
+  }>('SELECT name, email, status, guests, notes, created_at FROM rsvps WHERE event_id = ? ORDER BY created_at DESC', [eventId]);
+
+  const csv = [
+    ['name', 'email', 'status', 'guests', 'notes', 'submitted_at'].join(','),
+    ...rows.map((row) => [
+      csvEscape(row.name),
+      csvEscape(row.email),
+      csvEscape(row.status),
+      csvEscape(row.guests),
+      csvEscape(row.notes ?? ''),
+      csvEscape(row.created_at),
+    ].join(',')),
+  ].join('\n');
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="event-${eventId}-rsvps.csv"`);
+  return res.send(csv);
 }

--- a/backend/src/controllers/tasks-controller.ts
+++ b/backend/src/controllers/tasks-controller.ts
@@ -5,43 +5,80 @@ interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
 }
 
+const ALLOWED_STATUSES = new Set(['Pending', 'Complete', 'Completed', 'In Progress', 'Blocked']);
+const ALLOWED_PRIORITIES = new Set(['Low', 'Medium', 'High']);
+
+function normalizeTaskStatus(status?: string): string {
+  return status === 'Completed' ? 'Complete' : status ?? 'Pending';
+}
+
+async function getTaskTeamMemberIds(db: ReturnType<typeof getDatabase>, eventId: string): Promise<Set<number>> {
+  const rows = await db.all<{ user_id: number }>('SELECT user_id FROM event_members WHERE event_id = ?', [eventId]);
+  return new Set(rows.map((row) => Number(row.user_id)));
+}
+
 /** GET /api/events/:eventId/tasks */
 export async function listTasks(req: Request, res: Response): Promise<Response> {
   const db = getDatabase();
   const { eventId } = req.params;
-  const rows = await db.all('SELECT * FROM tasks WHERE event_id = ? ORDER BY due_date ASC', [eventId]);
+  const rows = await db.all(
+    `SELECT t.*, COALESCE(u.display_name, t.assignee_name) AS assignee_name
+     FROM tasks t
+     LEFT JOIN users u ON t.assigned_user_id = u.id
+     WHERE t.event_id = ?
+     ORDER BY t.due_date ASC, t.priority ASC`,
+    [eventId],
+  );
   return res.json({ tasks: rows });
 }
 
 /** POST /api/events/:eventId/tasks */
 export async function createTask(req: AuthRequest, res: Response): Promise<Response> {
   const { eventId } = req.params;
-  const { title, notes, assignee_name, due_date, status } = req.body as {
+  const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = req.body as {
     title?: string;
     notes?: string;
     assignee_name?: string;
+    assigned_user_id?: number | string;
     due_date?: string;
     status?: string;
+    priority?: string;
   };
 
   if (!title?.trim()) return res.status(400).json({ error: 'Task title is required.' });
+  if (status && !ALLOWED_STATUSES.has(status)) return res.status(400).json({ error: 'Invalid task status.' });
+  if (priority && !ALLOWED_PRIORITIES.has(priority)) return res.status(400).json({ error: 'Invalid priority.' });
 
   const db = getDatabase();
 
   const event = await db.get('SELECT id FROM events WHERE id = ? AND deleted_at IS NULL', [eventId]);
   if (!event) return res.status(404).json({ error: 'Event not found.' });
 
+  let assignedUserId: number | null = null;
+  let derivedAssigneeName = assignee_name?.trim() || null;
+  if (assigned_user_id !== undefined && assigned_user_id !== null && assigned_user_id !== '') {
+    assignedUserId = Number(assigned_user_id);
+    if (!Number.isInteger(assignedUserId)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+    const teamMembers = await getTaskTeamMemberIds(db, eventId);
+    if (!teamMembers.has(assignedUserId)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+    const assignee = await db.get<{ display_name: string }>('SELECT display_name FROM users WHERE id = ? AND deleted_at IS NULL', [assignedUserId]);
+    if (!assignee) return res.status(404).json({ error: 'Assigned user not found.' });
+    derivedAssigneeName = assignee.display_name;
+  }
+
   const result = await db.run(
-    `INSERT INTO tasks (event_id, title, notes, assignee_name, due_date, status, created_by)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO tasks (event_id, title, notes, assignee_name, assigned_user_id, due_date, status, priority, created_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      RETURNING id`,
     [
       eventId,
       title.trim(),
       notes?.trim() || null,
-      assignee_name?.trim() || null,
+      derivedAssigneeName,
+      assignedUserId,
       due_date || null,
-      status || 'Pending',
+      normalizeTaskStatus(status),
+      priority || 'Medium',
       req.user!.id,
     ],
   );
@@ -58,15 +95,38 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
   const task = await db.get('SELECT * FROM tasks WHERE id = ?', [id]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
-  const { title, notes, assignee_name, due_date, status } = req.body as Record<string, string>;
+  const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = req.body as Record<string, string>;
   const fields: string[] = [];
-  const params: (string | null)[] = [];
+  const params: (string | number | null)[] = [];
+
+  let derivedAssigneeName = assignee_name;
+  if (assigned_user_id !== undefined) {
+    const assignedUserId = Number(assigned_user_id);
+    if (!Number.isInteger(assignedUserId)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+    const teamMembers = await getTaskTeamMemberIds(db, String(task.event_id));
+    if (!teamMembers.has(assignedUserId)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+    const assignee = await db.get<{ display_name: string }>('SELECT display_name FROM users WHERE id = ? AND deleted_at IS NULL', [assignedUserId]);
+    if (!assignee) return res.status(404).json({ error: 'Assigned user not found.' });
+    fields.push('assigned_user_id = ?');
+    params.push(assignedUserId);
+    fields.push('assignee_name = ?');
+    params.push(assignee.display_name);
+  }
 
   if (title !== undefined) { fields.push('title = ?'); params.push(title.trim()); }
   if (notes !== undefined) { fields.push('notes = ?'); params.push(notes.trim() || null); }
-  if (assignee_name !== undefined) { fields.push('assignee_name = ?'); params.push(assignee_name.trim() || null); }
   if (due_date !== undefined) { fields.push('due_date = ?'); params.push(due_date || null); }
-  if (status !== undefined) { fields.push('status = ?'); params.push(status); }
+  if (status !== undefined) {
+    if (!ALLOWED_STATUSES.has(status)) return res.status(400).json({ error: 'Invalid task status.' });
+    fields.push('status = ?');
+    params.push(normalizeTaskStatus(status));
+  }
+  if (priority !== undefined) {
+    if (!ALLOWED_PRIORITIES.has(priority)) return res.status(400).json({ error: 'Invalid priority.' });
+    fields.push('priority = ?');
+    params.push(priority);
+  }
+  if (assignee_name !== undefined && assigned_user_id === undefined) { fields.push('assignee_name = ?'); params.push(assignee_name.trim() || null); }
 
   if (fields.length === 0) return res.status(400).json({ error: 'No fields to update.' });
 
@@ -74,7 +134,13 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
   params.push(id);
 
   await db.run(`UPDATE tasks SET ${fields.join(', ')} WHERE id = ?`, params);
-  const updated = await db.get('SELECT * FROM tasks WHERE id = ?', [id]);
+  const updated = await db.get(
+    `SELECT t.*, COALESCE(u.display_name, t.assignee_name) AS assignee_name
+     FROM tasks t
+     LEFT JOIN users u ON t.assigned_user_id = u.id
+     WHERE t.id = ?`,
+    [id],
+  );
   return res.json({ task: updated });
 }
 

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -279,6 +279,7 @@ async function runMigrations(db: DbWrapper): Promise<void> {
       created_by INTEGER NOT NULL,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      deleted_at TIMESTAMP,
       FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
     )
   `);

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -12,20 +12,25 @@ export interface RunResult {
   changes: number;
 }
 
-/**
- * Converts SQLite-style ? positional placeholders to PostgreSQL $N style.
+/*
+ * Unified database initialization supporting SQLite (default for dev)
+ * and PostgreSQL (when DATABASE_URL points to Postgres).
  */
+
+import pg from 'pg';
+
+export interface RunResult {
+  lastID?: number;
+  changes: number;
+}
+
 function convertPlaceholders(sql: string): string {
   let index = 0;
   return sql.replace(/\?/g, () => `$${++index}`);
 }
 
-/**
- * SQLite-compatible wrapper around a PostgreSQL Pool.
- * Provides get / all / run / exec so existing controller code needs
- * minimal changes beyond fixing SQLite-specific SQL syntax.
- */
-export class DbWrapper {
+// Postgres wrapper (keeps existing behaviour)
+class PgWrapper {
   private pool: pg.Pool;
 
   constructor(pool: pg.Pool) {
@@ -44,10 +49,6 @@ export class DbWrapper {
     return result.rows as T[];
   }
 
-  /**
-   * Executes a DML statement.
-   * If the SQL contains a RETURNING clause, rows[0].id is surfaced as lastID.
-   */
   async run(sql: string, params?: any[]): Promise<RunResult> {
     const trimmedUpper = sql.trim().toUpperCase();
     const converted = convertPlaceholders(sql);
@@ -61,45 +62,110 @@ export class DbWrapper {
   }
 }
 
-let dbWrapper: DbWrapper | null = null;
+// SQLite wrapper implementing same API
+class SqliteWrapper {
+  public isSqlite = true;
+  private db: any;
+
+  constructor(db: any) {
+    this.db = db;
+  }
+
+  async get<T = any>(sql: string, params?: any[]): Promise<T | undefined> {
+    return new Promise((resolve, reject) => {
+      this.db.get(sql, params || [], (err: any, row: T) => {
+        if (err) return reject(err);
+        resolve(row);
+      });
+    });
+  }
+
+  async all<T = any>(sql: string, params?: any[]): Promise<T[]> {
+    return new Promise((resolve, reject) => {
+      this.db.all(sql, params || [], (err: any, rows: T[]) => {
+        if (err) return reject(err);
+        resolve(rows);
+      });
+    });
+  }
+
+  async run(sql: string, params?: any[]): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+      this.db.run(sql, params || [], function (this: any, err: any) {
+        if (err) return reject(err);
+        resolve({ lastID: this.lastID as number | undefined, changes: this.changes ?? 0 });
+      });
+    });
+  }
+
+  async exec(sql: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.db.exec(sql, (err: any) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.db.close((err: any) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  }
+}
+
+let dbWrapper: any = null;
 let pool: pg.Pool | null = null;
 
-/**
- * Initializes the PostgreSQL connection pool and runs schema migrations.
- */
-export async function initializeDatabase(): Promise<DbWrapper> {
+function looksLikeSqlite(conn: string | undefined): boolean {
+  if (!conn) return true; // default to sqlite when unspecified
+  return conn.startsWith('sqlite') || conn.endsWith('.sqlite') || conn.startsWith('./') || conn.startsWith('/');
+}
+
+export async function initializeDatabase(): Promise<any> {
   if (dbWrapper) return dbWrapper;
 
-  const connectionString =
-    process.env.DATABASE_URL ||
-    'postgresql://postgres:postgres@localhost:5432/festival_planner';
+  const connectionString = process.env.DATABASE_URL || './database/dev.sqlite';
 
+  if (looksLikeSqlite(connectionString)) {
+    const sqlite3Mod = await import('sqlite3');
+    const sqlite3 = sqlite3Mod.default ?? sqlite3Mod;
+    sqlite3.verbose();
+    const dbFile = connectionString.replace(/^sqlite:(?:\/\/)?/, '');
+    // Ensure directory exists (caller is responsible for database folder in repo)
+    const sqliteDb = new sqlite3.Database(dbFile);
+    const wrapper = new SqliteWrapper(sqliteDb);
+    dbWrapper = wrapper;
+    // Enable foreign keys for SQLite
+    await dbWrapper.exec('PRAGMA foreign_keys = ON');
+    await runMigrations(dbWrapper);
+    return dbWrapper;
+  }
+
+  // Else Postgres
+  const { Pool } = pg;
   pool = new Pool({ connectionString });
-
-  // Verify connectivity
   const client = await pool.connect();
   client.release();
-
-  dbWrapper = new DbWrapper(pool);
+  dbWrapper = new PgWrapper(pool);
   await runMigrations(dbWrapper);
-
   return dbWrapper;
 }
 
-/**
- * Returns the initialised database wrapper.
- */
-export function getDatabase(): DbWrapper {
-  if (!dbWrapper) {
-    throw new Error('Database not initialized. Call initializeDatabase() first.');
-  }
+export function getDatabase(): any {
+  if (!dbWrapper) throw new Error('Database not initialized. Call initializeDatabase() first.');
   return dbWrapper;
 }
 
-/**
- * Closes the database connection pool.
- */
 export async function closeDatabase(): Promise<void> {
+  if (dbWrapper && dbWrapper.isSqlite) {
+    await dbWrapper.close();
+    dbWrapper = null;
+    return;
+  }
   if (pool) {
     await pool.end();
     pool = null;
@@ -107,12 +173,198 @@ export async function closeDatabase(): Promise<void> {
   }
 }
 
-/**
- * Creates all application tables if they do not already exist and seeds
- * required reference data (roles, permissions).
- */
-async function runMigrations(db: DbWrapper): Promise<void> {
-  // Create users table
+async function runMigrations(db: any): Promise<void> {
+  if (db.isSqlite) {
+    // SQLite-specific DDL (use INSERT OR IGNORE for idempotent seeds)
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        email_verified INTEGER DEFAULT 0,
+        email_verified_at TEXT,
+        email_verification_token TEXT,
+        pending_email TEXT,
+        pending_email_token TEXT,
+        pending_email_token_expiry TEXT,
+        role_id INTEGER DEFAULT 1,
+        account_locked INTEGER DEFAULT 0,
+        locked_until TEXT,
+        login_attempts INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        deleted_at TEXT
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        token TEXT NOT NULL UNIQUE,
+        refresh_token TEXT NOT NULL UNIQUE,
+        expires_at TEXT NOT NULL,
+        last_activity TEXT DEFAULT CURRENT_TIMESTAMP,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS password_reset_tokens (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
+        email TEXT NOT NULL,
+        token_selector TEXT NOT NULL DEFAULT '',
+        token TEXT NOT NULL UNIQUE,
+        expires_at TEXT NOT NULL,
+        used INTEGER DEFAULT 0,
+        used_at TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS password_reset_rate_limit (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL,
+        request_count INTEGER DEFAULT 1,
+        window_start TEXT DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(email)
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS audit_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
+        email TEXT,
+        action TEXT NOT NULL,
+        description TEXT,
+        ip_address TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS roles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE NOT NULL,
+        description TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await db.exec(`
+      INSERT OR IGNORE INTO roles (id, name, description) VALUES
+      (1, 'Attendee', 'Default role for new users'),
+      (2, 'Organizer', 'Can create and manage events'),
+      (3, 'Admin', 'Full system access')
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS permissions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE NOT NULL,
+        description TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS role_permissions (
+        role_id INTEGER NOT NULL,
+        permission_id INTEGER NOT NULL,
+        PRIMARY KEY (role_id, permission_id),
+        FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+        FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS user_profiles (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER UNIQUE NOT NULL,
+        bio TEXT,
+        phone_number TEXT,
+        profile_photo_url TEXT,
+        address TEXT,
+        city TEXT,
+        state TEXT,
+        zip_code TEXT,
+        country TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+      )
+    `);
+
+    await db.exec(`
+      INSERT OR IGNORE INTO permissions (name, description) VALUES
+      ('users.view',   'View user profiles'),
+      ('users.edit',   'Edit user profiles'),
+      ('users.delete', 'Delete users'),
+      ('events.view',  'View events'),
+      ('events.create','Create events'),
+      ('events.edit',  'Edit events'),
+      ('events.delete','Delete events'),
+      ('roles.view',   'View roles'),
+      ('roles.manage', 'Manage roles and permissions')
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        date TEXT NOT NULL,
+        location TEXT NOT NULL,
+        description TEXT,
+        status TEXT DEFAULT 'Draft',
+        created_by INTEGER NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        deleted_at TEXT,
+        FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS tasks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        assignee TEXT,
+        due_date TEXT,
+        status TEXT DEFAULT 'Pending',
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+      )
+    `);
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS rsvps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        email TEXT NOT NULL,
+        guests INTEGER DEFAULT 1,
+        status TEXT DEFAULT 'Pending',
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(event_id, email),
+        FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+      )
+    `);
+
+    return;
+  }
+
+  // Postgres migrations (existing SQL)
   await db.exec(`
     CREATE TABLE IF NOT EXISTS users (
       id SERIAL PRIMARY KEY,
@@ -135,7 +387,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create sessions table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
       id SERIAL PRIMARY KEY,
@@ -149,7 +400,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create password_reset_tokens table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS password_reset_tokens (
       id SERIAL PRIMARY KEY,
@@ -165,7 +415,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create password_reset_rate_limit table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS password_reset_rate_limit (
       id SERIAL PRIMARY KEY,
@@ -176,7 +425,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create audit_log table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS audit_log (
       id SERIAL PRIMARY KEY,
@@ -190,7 +438,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create roles table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS roles (
       id SERIAL PRIMARY KEY,
@@ -200,7 +447,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Seed default roles (idempotent)
   await db.exec(`
     INSERT INTO roles (id, name, description) VALUES
     (1, 'Attendee', 'Default role for new users'),
@@ -209,10 +455,8 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     ON CONFLICT (id) DO NOTHING
   `);
 
-  // Advance the sequence past the seeded ids to avoid PK conflicts on later inserts
   await db.exec(`SELECT setval('roles_id_seq', GREATEST((SELECT MAX(id) FROM roles), 3))`);
 
-  // Create permissions table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS permissions (
       id SERIAL PRIMARY KEY,
@@ -222,7 +466,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create role_permissions junction table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS role_permissions (
       role_id INTEGER NOT NULL,
@@ -233,7 +476,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create user_profiles table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS user_profiles (
       id SERIAL PRIMARY KEY,
@@ -252,7 +494,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Seed default permissions (idempotent)
   await db.exec(`
     INSERT INTO permissions (name, description) VALUES
     ('users.view',   'View user profiles'),
@@ -267,7 +508,6 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     ON CONFLICT (name) DO NOTHING
   `);
 
-  // Create events table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS events (
       id SERIAL PRIMARY KEY,
@@ -275,6 +515,7 @@ async function runMigrations(db: DbWrapper): Promise<void> {
       date TEXT NOT NULL,
       location TEXT NOT NULL,
       description TEXT,
+      capacity INTEGER,
       status TEXT CHECK(status IN ('Draft', 'Active', 'Completed')) DEFAULT 'Draft',
       created_by INTEGER NOT NULL,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -284,23 +525,26 @@ async function runMigrations(db: DbWrapper): Promise<void> {
     )
   `);
 
-  // Create tasks table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS tasks (
       id SERIAL PRIMARY KEY,
       event_id INTEGER NOT NULL,
       title TEXT NOT NULL,
-      description TEXT,
-      assignee TEXT,
+      notes TEXT,
+      assignee_name TEXT,
+      assigned_user_id INTEGER,
       due_date TEXT,
-      status TEXT CHECK(status IN ('Pending', 'Complete')) DEFAULT 'Pending',
+      status TEXT CHECK(status IN ('Pending', 'In Progress', 'Blocked', 'Complete')) DEFAULT 'Pending',
+      priority TEXT CHECK(priority IN ('Low', 'Medium', 'High')) DEFAULT 'Medium',
+      created_by INTEGER,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (assigned_user_id) REFERENCES users(id) ON DELETE SET NULL,
+      FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
       FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
     )
   `);
 
-  // Create rsvps table
   await db.exec(`
     CREATE TABLE IF NOT EXISTS rsvps (
       id SERIAL PRIMARY KEY,
@@ -308,11 +552,25 @@ async function runMigrations(db: DbWrapper): Promise<void> {
       name TEXT NOT NULL,
       email TEXT NOT NULL,
       guests INTEGER DEFAULT 1,
-      status TEXT CHECK(status IN ('Pending', 'Confirmed', 'Declined')) DEFAULT 'Pending',
+      status TEXT CHECK(status IN ('Pending', 'Going', 'Maybe', 'Not Going', 'Declined')) DEFAULT 'Pending',
+      notes TEXT,
+      source TEXT DEFAULT 'public',
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       UNIQUE(event_id, email),
       FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+    )
+  `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS event_members (
+      event_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      role TEXT DEFAULT 'Member',
+      joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (event_id, user_id),
+      FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     )
   `);
 }

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -6,7 +6,8 @@ import * as rbacController from '../controllers/rbac-controller.js';
 import * as passwordResetController from '../controllers/password-reset-controller.js';
 import * as eventController from '../controllers/event-controller.js';
 import * as taskController from '../controllers/task-controller.js';
-import * as rsvpController from '../controllers/rsvp-controller.js';
+import * as rsvpController from '../controllers/rsvps-controller.js';
+import * as eventMembersController from '../controllers/event-members-controller.js';
 import { authenticateToken, authorizeRole, authorizePermission } from '../middleware/auth.js';
 import rateLimit from 'express-rate-limit';
 import multer from 'multer';
@@ -57,6 +58,9 @@ router.post('/auth/login', authController.login);
 router.post('/auth/logout', authenticateToken, authController.logout);
 router.get('/auth/me', authenticateToken, authController.getCurrentUser);
 
+
+// ============ PUBLIC RSVP ROUTES ==========
+router.get('/public/events/:eventId', rsvpController.getPublicRsvpContext);
 // Token refresh and heartbeat
 router.post('/auth/refresh', authController.refreshTokenEndpoint);
 router.post('/auth/session/heartbeat', authenticateToken, authController.sessionHeartbeat);
@@ -72,6 +76,16 @@ router.delete('/profile/account', authenticateToken, profileController.deleteAcc
 // ============ USER (self-service) ROUTES — issues #36, #39 ============
 router.get('/users/me', authenticateToken, usersController.getMe);
 router.patch('/users/me', authenticateToken, usersController.updateMe);
+router.get('/events/:eventId/rsvps', authenticateToken, rsvpController.listRsvps);
+router.post('/events/:eventId/rsvps', rsvpController.createRsvp);
+router.patch('/events/:eventId/rsvps/:id', authenticateToken, rsvpController.updateRsvp);
+router.delete('/events/:eventId/rsvps/:id', authenticateToken, rsvpController.deleteRsvp);
+router.get('/events/:eventId/rsvps/export', authenticateToken, rsvpController.exportRsvpsCsv);
+
+// ============ EVENT MEMBERS ROUTES ==========
+router.get('/events/:eventId/members', authenticateToken, eventMembersController.listMembers);
+router.post('/events/:eventId/members', authenticateToken, eventMembersController.addMember);
+router.delete('/events/:eventId/members/:userId', authenticateToken, eventMembersController.removeMember);
 router.delete('/users/me', authenticateToken, usersController.deleteMe);
 
 // ============ PROFILE ROUTES (extended data) ============

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -122,6 +122,7 @@ router.get('/events/:id', authenticateToken, eventController.getEventById);
 router.post('/events', authenticateToken, eventController.createEvent);
 router.put('/events/:id', authenticateToken, eventController.updateEvent);
 router.delete('/events/:id', authenticateToken, eventController.deleteEvent);
+router.post('/events/:id/restore', authenticateToken, eventController.restoreEvent);
 
 // ============ TASK ROUTES ============
 router.get('/tasks', authenticateToken, taskController.getAllTasks);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { AppNav } from './components/nav/app-nav';
 import Dashboard from './components/dashboard/Dashboard';
 import EventsPage from './components/events/events-page';
 import EventDetailPage from './components/events/event-detail-page';
+import PublicRsvpPage from './components/events/public-rsvp-page';
 import ProfilePage from './components/profile/profile-page';
 import AdminPage from './components/admin/admin-page';
 import { AiAssistant } from './components/ai/ai-assistant';
@@ -123,6 +124,7 @@ function RootRouter(): JSX.Element {
       <Route path="/register" element={user ? <Navigate to="/dashboard" replace /> : <AuthShell />} />
       <Route path="/forgot-password" element={<AuthShell />} />
       <Route path="/reset-password" element={<AuthShell />} />
+      <Route path="/rsvp/:eventId" element={<PublicRsvpPage />} />
       <Route path="/*" element={<AppShell />} />
     </Routes>
   );

--- a/frontend/src/components/events/event-detail-page.tsx
+++ b/frontend/src/components/events/event-detail-page.tsx
@@ -35,6 +35,7 @@ interface PlannerEvent {
   description: string | null;
   location: string | null;
   event_date: string;
+  capacity: number | null;
   status: string;
   creator_name: string | null;
 }
@@ -44,22 +45,42 @@ interface Task {
   title: string;
   notes: string | null;
   assignee_name: string | null;
+  assigned_user_id: number | null;
   due_date: string | null;
   status: string;
+  priority: string;
 }
 
 interface Rsvp {
   id: number;
   name: string;
   email: string;
+  guests: number;
   status: string;
   notes: string | null;
   source: string;
 }
 
-const TASK_STATUSES = ['Pending', 'In Progress', 'Completed'];
-const RSVP_STATUSES = ['Going', 'Maybe', 'Not Going', 'Pending'];
+interface EventMember {
+  user_id: number;
+  display_name: string;
+  email: string;
+  role: string;
+  joined_at: string;
+}
 
+interface UserOption {
+  user_id: number;
+  display_name: string;
+  email: string;
+  role_name: string | null;
+}
+
+const TASK_STATUSES = ['Pending', 'In Progress', 'Blocked', 'Complete', 'Completed'];
+const TASK_PRIORITIES = ['Low', 'Medium', 'High'];
+const RSVP_STATUSES = ['Pending', 'Going', 'Maybe', 'Not Going', 'Declined'];
+const RSVP_EXPORT_FORMAT = 'csv';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 export default function EventDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -67,6 +88,8 @@ export default function EventDetailPage(): JSX.Element {
   const [event, setEvent] = useState<PlannerEvent | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [rsvps, setRsvps] = useState<Rsvp[]>([]);
+  const [members, setMembers] = useState<EventMember[]>([]);
+  const [availableUsers, setAvailableUsers] = useState<UserOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState(0);
@@ -74,24 +97,40 @@ export default function EventDetailPage(): JSX.Element {
   // Task dialog
   const [taskDialog, setTaskDialog] = useState(false);
   const [editTaskId, setEditTaskId] = useState<number | null>(null);
-  const [taskForm, setTaskForm] = useState({ title: '', notes: '', assignee_name: '', due_date: '', status: 'Pending' });
+  const [taskForm, setTaskForm] = useState({ title: '', notes: '', assigned_user_id: '', due_date: '', status: 'Pending', priority: 'Medium' });
   const [taskSaving, setTaskSaving] = useState(false);
+  const [taskError, setTaskError] = useState<string | null>(null);
 
   // RSVP dialog
   const [rsvpDialog, setRsvpDialog] = useState(false);
   const [editRsvpId, setEditRsvpId] = useState<number | null>(null);
-  const [rsvpForm, setRsvpForm] = useState({ name: '', email: '', status: 'Pending', notes: '' });
+  const [rsvpForm, setRsvpForm] = useState({ name: '', email: '', guests: '1', status: 'Pending', notes: '' });
   const [rsvpSaving, setRsvpSaving] = useState(false);
+  const [rsvpError, setRsvpError] = useState<string | null>(null);
+
+  // Team dialog state
+  const [memberUserId, setMemberUserId] = useState('');
+  const [memberRole, setMemberRole] = useState('Member');
+  const [memberSaving, setMemberSaving] = useState(false);
+  const [memberError, setMemberError] = useState<string | null>(null);
 
   const canEdit = user && user.roleId >= 2;
+  const remainingCapacity = event?.capacity === null || event?.capacity === undefined
+    ? null
+    : Math.max(
+      event.capacity - rsvps.reduce((sum, rsvp) => sum + (rsvp.status === 'Going' ? Number(rsvp.guests || 1) : 0), 0),
+      0,
+    );
 
   async function load(): Promise<void> {
     setLoading(true);
     try {
-      const data = await api.get<{ event: PlannerEvent; tasks: Task[]; rsvps: Rsvp[] }>(`/api/events/${id}`);
+      const data = await api.get<{ event: PlannerEvent; tasks: Task[]; rsvps: Rsvp[]; members: EventMember[]; availableUsers: UserOption[] }>(`/api/events/${id}`);
       setEvent(data.event);
       setTasks(data.tasks);
       setRsvps(data.rsvps);
+      setMembers(data.members ?? []);
+      setAvailableUsers(data.availableUsers ?? []);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load event.');
     } finally {
@@ -104,29 +143,46 @@ export default function EventDetailPage(): JSX.Element {
   // ---- Tasks ----
   function openAddTask(): void {
     setEditTaskId(null);
-    setTaskForm({ title: '', notes: '', assignee_name: '', due_date: '', status: 'Pending' });
+    setTaskForm({ title: '', notes: '', assigned_user_id: '', due_date: '', status: 'Pending', priority: 'Medium' });
+    setTaskError(null);
     setTaskDialog(true);
   }
 
   function openEditTask(t: Task): void {
     setEditTaskId(t.id);
-    setTaskForm({ title: t.title, notes: t.notes ?? '', assignee_name: t.assignee_name ?? '', due_date: t.due_date ?? '', status: t.status });
+    setTaskForm({
+      title: t.title,
+      notes: t.notes ?? '',
+      assigned_user_id: t.assigned_user_id ? String(t.assigned_user_id) : '',
+      due_date: t.due_date ?? '',
+      status: t.status,
+      priority: t.priority ?? 'Medium',
+    });
+    setTaskError(null);
     setTaskDialog(true);
   }
 
   async function saveTask(e: FormEvent): Promise<void> {
     e.preventDefault();
+    setTaskError(null);
     setTaskSaving(true);
     try {
+      const assignedUserId = taskForm.assigned_user_id ? Number(taskForm.assigned_user_id) : null;
       if (editTaskId) {
-        await api.patch(`/api/events/${id}/tasks/${editTaskId}`, taskForm);
+        await api.patch(`/api/events/${id}/tasks/${editTaskId}`, {
+          ...taskForm,
+          assigned_user_id: assignedUserId,
+        });
       } else {
-        await api.post(`/api/events/${id}/tasks`, taskForm);
+        await api.post(`/api/events/${id}/tasks`, {
+          ...taskForm,
+          assigned_user_id: assignedUserId,
+        });
       }
       setTaskDialog(false);
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Save failed.');
+      setTaskError(err instanceof ApiError ? err.message : 'Save failed.');
     } finally {
       setTaskSaving(false);
     }
@@ -141,29 +197,33 @@ export default function EventDetailPage(): JSX.Element {
   // ---- RSVPs ----
   function openAddRsvp(): void {
     setEditRsvpId(null);
-    setRsvpForm({ name: '', email: '', status: 'Pending', notes: '' });
+    setRsvpForm({ name: '', email: '', guests: '1', status: 'Pending', notes: '' });
+    setRsvpError(null);
     setRsvpDialog(true);
   }
 
   function openEditRsvp(r: Rsvp): void {
     setEditRsvpId(r.id);
-    setRsvpForm({ name: r.name, email: r.email, status: r.status, notes: r.notes ?? '' });
+    setRsvpForm({ name: r.name, email: r.email, guests: String(r.guests ?? 1), status: r.status, notes: r.notes ?? '' });
+    setRsvpError(null);
     setRsvpDialog(true);
   }
 
   async function saveRsvp(e: FormEvent): Promise<void> {
     e.preventDefault();
+    setRsvpError(null);
     setRsvpSaving(true);
     try {
+      const guests = Number(rsvpForm.guests || 1);
       if (editRsvpId) {
-        await api.patch(`/api/events/${id}/rsvps/${editRsvpId}`, rsvpForm);
+        await api.patch(`/api/events/${id}/rsvps/${editRsvpId}`, { ...rsvpForm, guests });
       } else {
-        await api.post(`/api/events/${id}/rsvps`, rsvpForm);
+        await api.post(`/api/events/${id}/rsvps`, { ...rsvpForm, guests });
       }
       setRsvpDialog(false);
       await load();
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Save failed.');
+      setRsvpError(err instanceof ApiError ? err.message : 'Save failed.');
     } finally {
       setRsvpSaving(false);
     }
@@ -172,6 +232,54 @@ export default function EventDetailPage(): JSX.Element {
   async function deleteRsvp(rsvpId: number): Promise<void> {
     if (!window.confirm('Delete this RSVP?')) return;
     await api.delete(`/api/events/${id}/rsvps/${rsvpId}`).catch((err) => setError(err.message));
+    await load();
+  }
+
+  async function exportRsvpsCsv(): Promise<void> {
+    try {
+      const token = localStorage.getItem('accessToken');
+      const response = await fetch(`${API_BASE}/api/events/${id}/rsvps/export?format=${RSVP_EXPORT_FORMAT}`, {
+        method: 'GET',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({ error: response.statusText })) as { error?: string };
+        throw new Error(body.error ?? response.statusText);
+      }
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const link = window.document.createElement('a');
+      link.href = objectUrl;
+      link.download = `event-${id}-rsvps.csv`;
+      link.click();
+      URL.revokeObjectURL(objectUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'CSV export failed.');
+    }
+  }
+
+  async function addMember(): Promise<void> {
+    if (!memberUserId) {
+      setMemberError('Please choose a user to add.');
+      return;
+    }
+    setMemberSaving(true);
+    setMemberError(null);
+    try {
+      await api.post(`/api/events/${id}/members`, { user_id: Number(memberUserId), role: memberRole });
+      setMemberUserId('');
+      setMemberRole('Member');
+      await load();
+    } catch (err) {
+      setMemberError(err instanceof ApiError ? err.message : 'Failed to add member.');
+    } finally {
+      setMemberSaving(false);
+    }
+  }
+
+  async function removeMember(userId: number): Promise<void> {
+    if (!window.confirm('Remove this team member?')) return;
+    await api.delete(`/api/events/${id}/members/${userId}`).catch((err) => setError(err.message));
     await load();
   }
 
@@ -198,6 +306,11 @@ export default function EventDetailPage(): JSX.Element {
             <Typography variant="body2" color="text.secondary">
               {new Date(event.event_date).toLocaleDateString()} {event.location ? `· ${event.location}` : ''}
             </Typography>
+            {event.capacity !== null && event.capacity !== undefined && (
+              <Typography variant="body2" color="text.secondary">
+                Capacity: {event.capacity} {remainingCapacity !== null ? `· Remaining: ${remainingCapacity}` : ''}
+              </Typography>
+            )}
             {event.description && <Typography variant="body1" sx={{ mt: 1 }}>{event.description}</Typography>}
           </Box>
           <Chip label={event.status} color={event.status === 'Active' ? 'primary' : event.status === 'Completed' ? 'success' : 'default'} />
@@ -207,6 +320,7 @@ export default function EventDetailPage(): JSX.Element {
       <Tabs value={tab} onChange={(_, v: number) => setTab(v)} sx={{ mb: 2 }}>
         <Tab label={`Tasks (${tasks.length})`} />
         <Tab label={`RSVPs (${rsvps.length})`} />
+        <Tab label={`Team (${members.length})`} />
       </Tabs>
       <Divider sx={{ mb: 2 }} />
 
@@ -228,6 +342,7 @@ export default function EventDetailPage(): JSX.Element {
                     <TableCell><strong>Title</strong></TableCell>
                     <TableCell><strong>Assignee</strong></TableCell>
                     <TableCell><strong>Due Date</strong></TableCell>
+                    <TableCell><strong>Priority</strong></TableCell>
                     <TableCell><strong>Status</strong></TableCell>
                     {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
                   </TableRow>
@@ -238,8 +353,9 @@ export default function EventDetailPage(): JSX.Element {
                       <TableCell>{t.title}</TableCell>
                       <TableCell>{t.assignee_name ?? '—'}</TableCell>
                       <TableCell>{t.due_date ? new Date(t.due_date).toLocaleDateString() : '—'}</TableCell>
+                      <TableCell><Chip label={t.priority ?? 'Medium'} size="small" variant="outlined" /></TableCell>
                       <TableCell>
-                        <Chip label={t.status} size="small" color={t.status === 'Completed' ? 'success' : t.status === 'In Progress' ? 'warning' : 'default'} />
+                        <Chip label={t.status} size="small" color={t.status === 'Complete' || t.status === 'Completed' ? 'success' : t.status === 'In Progress' ? 'warning' : t.status === 'Blocked' ? 'error' : 'default'} />
                       </TableCell>
                       {canEdit && (
                         <TableCell align="right">
@@ -261,11 +377,24 @@ export default function EventDetailPage(): JSX.Element {
       {/* RSVPs Tab */}
       {tab === 1 && (
         <>
-          {canEdit && (
-            <Button variant="contained" startIcon={<AddRounded />} sx={{ mb: 2 }} onClick={openAddRsvp}>
-              Add RSVP
-            </Button>
-          )}
+          <Stack direction="row" spacing={2} sx={{ mb: 2, flexWrap: 'wrap' }}>
+            {canEdit && (
+              <Button variant="contained" startIcon={<AddRounded />} onClick={openAddRsvp}>
+                Add RSVP
+              </Button>
+            )}
+            {canEdit && (
+              <Button variant="outlined" onClick={exportRsvpsCsv}>
+                Export CSV
+              </Button>
+            )}
+            {event.capacity !== null && event.capacity !== undefined && (
+              <Typography variant="body2" color="text.secondary" sx={{ alignSelf: 'center' }}>
+                Remaining capacity: {remainingCapacity === null ? 'n/a' : remainingCapacity}
+              </Typography>
+            )}
+          </Stack>
+          {rsvpError && <Alert severity="error" sx={{ mb: 2 }}>{rsvpError}</Alert>}
           {rsvps.length === 0 ? (
             <Paper sx={{ p: 3, textAlign: 'center' }}><Typography color="text.secondary">No RSVPs yet.</Typography></Paper>
           ) : (
@@ -275,6 +404,7 @@ export default function EventDetailPage(): JSX.Element {
                   <TableRow>
                     <TableCell><strong>Name</strong></TableCell>
                     <TableCell><strong>Email</strong></TableCell>
+                    <TableCell><strong>Guests</strong></TableCell>
                     <TableCell><strong>Status</strong></TableCell>
                     <TableCell><strong>Source</strong></TableCell>
                     {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
@@ -285,8 +415,9 @@ export default function EventDetailPage(): JSX.Element {
                     <TableRow key={r.id} hover>
                       <TableCell>{r.name}</TableCell>
                       <TableCell>{r.email}</TableCell>
+                      <TableCell>{r.guests ?? 1}</TableCell>
                       <TableCell>
-                        <Chip label={r.status} size="small" color={r.status === 'Going' ? 'success' : r.status === 'Maybe' ? 'warning' : 'default'} />
+                        <Chip label={r.status} size="small" color={r.status === 'Going' ? 'success' : r.status === 'Maybe' ? 'warning' : r.status === 'Declined' || r.status === 'Not Going' ? 'default' : 'default'} />
                       </TableCell>
                       <TableCell><Chip label={r.source} size="small" variant="outlined" /></TableCell>
                       {canEdit && (
@@ -306,15 +437,103 @@ export default function EventDetailPage(): JSX.Element {
         </>
       )}
 
+      {/* Team Tab */}
+      {tab === 2 && (
+        <>
+          {canEdit && (
+            <Paper sx={{ p: 2, mb: 2 }}>
+              <Stack spacing={2} direction={{ xs: 'column', md: 'row' }}>
+                <TextField
+                  label="Invite User"
+                  select
+                  value={memberUserId}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setMemberUserId(e.target.value)}
+                  fullWidth
+                >
+                  {availableUsers
+                    .filter((option) => !members.some((member) => member.user_id === option.user_id))
+                    .map((option) => (
+                      <MenuItem key={option.user_id} value={option.user_id}>
+                        {option.display_name} ({option.email})
+                      </MenuItem>
+                    ))}
+                </TextField>
+                <TextField
+                  label="Role"
+                  value={memberRole}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setMemberRole(e.target.value)}
+                  fullWidth
+                />
+                <Button variant="contained" onClick={addMember} disabled={memberSaving}>
+                  {memberSaving ? 'Adding…' : 'Invite'}
+                </Button>
+              </Stack>
+              {memberError && <Alert severity="error" sx={{ mt: 2 }}>{memberError}</Alert>}
+            </Paper>
+          )}
+          {members.length === 0 ? (
+            <Paper sx={{ p: 3, textAlign: 'center' }}><Typography color="text.secondary">No team members yet.</Typography></Paper>
+          ) : (
+            <TableContainer component={Paper}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell><strong>Name</strong></TableCell>
+                    <TableCell><strong>Email</strong></TableCell>
+                    <TableCell><strong>Role</strong></TableCell>
+                    <TableCell><strong>Joined</strong></TableCell>
+                    {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {members.map((member) => (
+                    <TableRow key={member.user_id} hover>
+                      <TableCell>{member.display_name}</TableCell>
+                      <TableCell>{member.email}</TableCell>
+                      <TableCell>{member.role}</TableCell>
+                      <TableCell>{new Date(member.joined_at).toLocaleString()}</TableCell>
+                      {canEdit && (
+                        <TableCell align="right">
+                          <Button size="small" color="error" onClick={() => removeMember(member.user_id)}>
+                            Remove
+                          </Button>
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </>
+      )}
+
       {/* Task Dialog */}
       <Dialog open={taskDialog} onClose={() => setTaskDialog(false)} maxWidth="sm" fullWidth>
         <DialogTitle>{editTaskId ? 'Edit Task' : 'New Task'}</DialogTitle>
         <DialogContent>
           <Box component="form" id="task-form" onSubmit={saveTask} noValidate>
             <Stack spacing={2} sx={{ mt: 1 }}>
+              {taskError && <Alert severity="error">{taskError}</Alert>}
               <TextField label="Title" value={taskForm.title} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, title: e.target.value }))} required fullWidth />
-              <TextField label="Assignee" value={taskForm.assignee_name} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, assignee_name: e.target.value }))} fullWidth />
+              <TextField
+                label="Assignee"
+                select
+                value={taskForm.assigned_user_id}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, assigned_user_id: e.target.value }))}
+                fullWidth
+              >
+                <MenuItem value="">Unassigned</MenuItem>
+                {availableUsers.map((option) => (
+                  <MenuItem key={option.user_id} value={option.user_id}>
+                    {option.display_name} ({option.email})
+                  </MenuItem>
+                ))}
+              </TextField>
               <TextField label="Due Date" type="date" value={taskForm.due_date} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, due_date: e.target.value }))} fullWidth InputLabelProps={{ shrink: true }} />
+              <TextField label="Priority" select value={taskForm.priority} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, priority: e.target.value }))} fullWidth>
+                {TASK_PRIORITIES.map((priority) => <MenuItem key={priority} value={priority}>{priority}</MenuItem>)}
+              </TextField>
               <TextField label="Notes" value={taskForm.notes} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, notes: e.target.value }))} multiline rows={2} fullWidth />
               <TextField label="Status" select value={taskForm.status} onChange={(e: ChangeEvent<HTMLInputElement>) => setTaskForm((p) => ({ ...p, status: e.target.value }))} fullWidth>
                 {TASK_STATUSES.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
@@ -337,8 +556,10 @@ export default function EventDetailPage(): JSX.Element {
         <DialogContent>
           <Box component="form" id="rsvp-form" onSubmit={saveRsvp} noValidate>
             <Stack spacing={2} sx={{ mt: 1 }}>
+              {rsvpError && <Alert severity="error">{rsvpError}</Alert>}
               <TextField label="Name" value={rsvpForm.name} onChange={(e: ChangeEvent<HTMLInputElement>) => setRsvpForm((p) => ({ ...p, name: e.target.value }))} required fullWidth />
               <TextField label="Email" type="email" value={rsvpForm.email} onChange={(e: ChangeEvent<HTMLInputElement>) => setRsvpForm((p) => ({ ...p, email: e.target.value }))} required fullWidth />
+              <TextField label="Guest Count" type="number" value={rsvpForm.guests} onChange={(e: ChangeEvent<HTMLInputElement>) => setRsvpForm((p) => ({ ...p, guests: e.target.value }))} inputProps={{ min: 1 }} fullWidth />
               <TextField label="Status" select value={rsvpForm.status} onChange={(e: ChangeEvent<HTMLInputElement>) => setRsvpForm((p) => ({ ...p, status: e.target.value }))} fullWidth>
                 {RSVP_STATUSES.map((s) => <MenuItem key={s} value={s}>{s}</MenuItem>)}
               </TextField>

--- a/frontend/src/components/events/events-page.tsx
+++ b/frontend/src/components/events/events-page.tsx
@@ -31,6 +31,7 @@ interface PlannerEvent {
   title: string;
   location: string | null;
   event_date: string;
+  capacity: number | null;
   status: string;
   creator_name: string | null;
 }
@@ -48,10 +49,11 @@ interface EventForm {
   description: string;
   location: string;
   event_date: string;
+  capacity: string;
   status: string;
 }
 
-const EMPTY_FORM: EventForm = { title: '', description: '', location: '', event_date: '', status: 'Draft' };
+const EMPTY_FORM: EventForm = { title: '', description: '', location: '', event_date: '', capacity: '', status: 'Draft' };
 
 export default function EventsPage(): JSX.Element {
   const { user } = useAuth();
@@ -95,6 +97,7 @@ export default function EventsPage(): JSX.Element {
       description: '',
       location: event.location ?? '',
       event_date: event.event_date,
+      capacity: event.capacity === null || event.capacity === undefined ? '' : String(event.capacity),
       status: event.status,
     });
     setSaveError(null);
@@ -107,9 +110,9 @@ export default function EventsPage(): JSX.Element {
     setSaving(true);
     try {
       if (editingId) {
-        await api.patch(`/api/events/${editingId}`, form);
+        await api.patch(`/api/events/${editingId}`, { ...form, capacity: form.capacity ? Number(form.capacity) : null });
       } else {
-        await api.post('/api/events', form);
+        await api.post('/api/events', { ...form, capacity: form.capacity ? Number(form.capacity) : null });
       }
       setDialogOpen(false);
       await loadEvents();
@@ -161,6 +164,7 @@ export default function EventsPage(): JSX.Element {
                 <TableCell><strong>Title</strong></TableCell>
                 <TableCell><strong>Date</strong></TableCell>
                 <TableCell><strong>Location</strong></TableCell>
+                <TableCell><strong>Capacity</strong></TableCell>
                 <TableCell><strong>Status</strong></TableCell>
                 <TableCell><strong>Created by</strong></TableCell>
                 <TableCell align="right"><strong>Actions</strong></TableCell>
@@ -172,6 +176,7 @@ export default function EventsPage(): JSX.Element {
                   <TableCell>{event.title}</TableCell>
                   <TableCell>{new Date(event.event_date).toLocaleDateString()}</TableCell>
                   <TableCell>{event.location ?? '—'}</TableCell>
+                  <TableCell>{event.capacity ?? '—'}</TableCell>
                   <TableCell>
                     <Chip
                       label={event.status}
@@ -213,6 +218,14 @@ export default function EventsPage(): JSX.Element {
               <TextField label="Title" value={form.title} onChange={handleField('title')} required fullWidth />
               <TextField label="Description" value={form.description} onChange={handleField('description')} multiline rows={3} fullWidth />
               <TextField label="Location" value={form.location} onChange={handleField('location')} fullWidth />
+              <TextField
+                label="Capacity"
+                type="number"
+                value={form.capacity}
+                onChange={handleField('capacity')}
+                fullWidth
+                inputProps={{ min: 1 }}
+              />
               <TextField
                 label="Event Date"
                 type="date"

--- a/frontend/src/components/events/public-rsvp-page.tsx
+++ b/frontend/src/components/events/public-rsvp-page.tsx
@@ -1,0 +1,157 @@
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { api, ApiError } from '../../lib/api-client';
+
+const RSVP_STATUSES = ['Pending', 'Going', 'Maybe', 'Not Going', 'Declined'];
+
+interface PublicRsvpEvent {
+  id: number;
+  title: string;
+  description: string | null;
+  location: string | null;
+  event_date: string;
+  capacity: number | null;
+}
+
+interface PublicRsvpContext {
+  event: PublicRsvpEvent;
+  remainingCapacity: number | null;
+}
+
+export default function PublicRsvpPage(): JSX.Element {
+  const { eventId } = useParams<{ eventId: string }>();
+  const [event, setEvent] = useState<PublicRsvpEvent | null>(null);
+  const [remainingCapacity, setRemainingCapacity] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [form, setForm] = useState({ name: '', email: '', guests: '1', status: 'Pending', notes: '' });
+
+  useEffect(() => {
+    async function load(): Promise<void> {
+      if (!eventId) {
+        setError('Missing event identifier.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const data = await api.get<PublicRsvpContext>(`/api/public/events/${eventId}`);
+        setEvent(data.event);
+        setRemainingCapacity(data.remainingCapacity);
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to load RSVP details.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void load();
+  }, [eventId]);
+
+  async function submit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (!eventId) {
+        throw new Error('Missing event identifier.');
+      }
+
+      await api.post(`/api/events/${eventId}/rsvps`, {
+        ...form,
+        guests: Number(form.guests || 1),
+      });
+      setSuccess('Your RSVP has been recorded.');
+      setForm({ name: '', email: '', guests: '1', status: 'Pending', notes: '' });
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to submit RSVP.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleField(field: 'name' | 'email' | 'guests' | 'status' | 'notes') {
+    return (e: ChangeEvent<HTMLInputElement>) => setForm((prev) => ({ ...prev, [field]: e.target.value }));
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center', px: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!event) {
+    return (
+      <Box sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center', px: 2 }}>
+        <Paper sx={{ p: 4, width: '100%', maxWidth: 560 }}>
+          <Alert severity="error">{error ?? 'Event not found.'}</Alert>
+        </Paper>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        px: 2,
+        py: 6,
+        background: 'radial-gradient(circle at top, #eef7ff 0%, #f7f8fc 55%, #eef3f7 100%)',
+      }}
+    >
+      <Paper sx={{ width: '100%', maxWidth: 720, mx: 'auto', p: { xs: 3, sm: 4 } }} elevation={8}>
+        <Stack spacing={1.5} sx={{ mb: 3 }}>
+          <Typography variant="overline" color="text.secondary">Public RSVP</Typography>
+          <Typography variant="h4" fontWeight={800}>{event.title}</Typography>
+          <Typography color="text.secondary">
+            {new Date(event.event_date).toLocaleDateString()}
+            {event.location ? ` · ${event.location}` : ''}
+          </Typography>
+          {event.capacity !== null && (
+            <Typography color="text.secondary">
+              Capacity: {event.capacity}{remainingCapacity !== null ? ` · Remaining: ${remainingCapacity}` : ''}
+            </Typography>
+          )}
+          {event.description && <Typography>{event.description}</Typography>}
+        </Stack>
+
+        {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+        {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
+
+        <Box component="form" onSubmit={submit} noValidate>
+          <Stack spacing={2}>
+            <TextField label="Name" value={form.name} onChange={handleField('name')} required fullWidth />
+            <TextField label="Email" type="email" value={form.email} onChange={handleField('email')} required fullWidth />
+            <TextField label="Guests" type="number" value={form.guests} onChange={handleField('guests')} inputProps={{ min: 1 }} fullWidth />
+            <TextField label="Status" select value={form.status} onChange={handleField('status')} helperText="Use Pending, Going, Maybe, Not Going, or Declined" fullWidth>
+              {RSVP_STATUSES.map((status) => (
+                <MenuItem key={status} value={status}>{status}</MenuItem>
+              ))}
+            </TextField>
+            <TextField label="Notes" value={form.notes} onChange={handleField('notes')} multiline rows={3} fullWidth />
+            <Button type="submit" variant="contained" size="large" disabled={saving}>
+              {saving ? 'Submitting…' : 'Submit RSVP'}
+            </Button>
+          </Stack>
+        </Box>
+      </Paper>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary\nImplements the Phase 5C RSVP and task enhancement bundle across backend, frontend, and routing.\n\n## Delivered\n- Event capacity support in the event schema and event create/edit UI.\n- Public RSVP context and public RSVP form at /rsvp/:eventId.\n- RSVP guest counts, capacity enforcement, and CSV export.\n- Event team member management and task assignment to event members.\n- Task priority support and richer task status handling.\n- Event detail page now loads event, tasks, RSVPs, team members, and available users together.\n\n## Story Links\n- Closes #292\n- Closes #293\n- Closes #294\n- Closes #295\n- Closes #296\n- Closes #297\n\n## Review Notes\n- Reviewer: @sumitprajapati29-sudo