### PR TITLE
fix(security): tighten auth endpoint rate limits #248

### DIFF
--- a/backend/__tests__/auth-rate-limits.test.ts
+++ b/backend/__tests__/auth-rate-limits.test.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createAuthLimiter } from '../src/middleware/rate-limit.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/auth/login', createAuthLimiter(), (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.post('/auth/register', createAuthLimiter(), (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.post('/auth/forgot-password', createAuthLimiter(), (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  return app;
+}
+
+async function expectRateLimitAfterTenRequests(path: '/auth/login' | '/auth/register' | '/auth/forgot-password') {
+  const app = buildApp();
+
+  for (let index = 0; index < 10; index += 1) {
+    const response = await request(app).post(path).send({ email: 'user@test.com', password: 'Pass1234' });
+    expect(response.status).toBe(200);
+  }
+
+  const limitedResponse = await request(app).post(path).send({ email: 'user@test.com', password: 'Pass1234' });
+  expect(limitedResponse.status).toBe(429);
+  expect(limitedResponse.body).toEqual({ error: 'Too many auth requests. Please try again later.' });
+}
+
+describe('Auth endpoint rate limits (#248)', () => {
+  it('returns 429 for /auth/login after 10 requests in 15 minutes', async () => {
+    await expectRateLimitAfterTenRequests('/auth/login');
+  });
+
+  it('returns 429 for /auth/register after 10 requests in 15 minutes', async () => {
+    await expectRateLimitAfterTenRequests('/auth/register');
+  });
+
+  it('returns 429 for /auth/forgot-password after 10 requests in 15 minutes', async () => {
+    await expectRateLimitAfterTenRequests('/auth/forgot-password');
+  });
+});

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,0 +1,11 @@
+import rateLimit from 'express-rate-limit';
+
+export const apiLimiter = rateLimit({ windowMs: 60_000, max: 100 });
+
+export const createAuthLimiter = () => rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many auth requests. Please try again later.' },
+});

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -9,14 +9,12 @@ import * as taskController from '../controllers/task-controller.js';
 import * as rsvpController from '../controllers/rsvps-controller.js';
 import * as eventMembersController from '../controllers/event-members-controller.js';
 import { authenticateToken, authorizeRole, authorizePermission } from '../middleware/auth.js';
-import rateLimit from 'express-rate-limit';
+import { apiLimiter, createAuthLimiter } from '../middleware/rate-limit.js';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { hashPassword } from '../utils/auth-helpers.js';
 import { getDatabase } from '../db/database.js';
-
-const apiLimiter = rateLimit({ windowMs: 60_000, max: 100 });
 
 const router = Router();
 
@@ -52,9 +50,9 @@ const upload = multer({
 });
 
 // ============ AUTH ROUTES ============
-router.post('/auth/register', authController.register);
+router.post('/auth/register', createAuthLimiter(), authController.register);
 router.post('/auth/verify-email', authController.verifyEmail);
-router.post('/auth/login', authController.login);
+router.post('/auth/login', createAuthLimiter(), authController.login);
 router.post('/auth/logout', authenticateToken, authController.logout);
 router.get('/auth/me', authenticateToken, authController.getCurrentUser);
 
@@ -66,7 +64,7 @@ router.post('/auth/refresh', authController.refreshTokenEndpoint);
 router.post('/auth/session/heartbeat', authenticateToken, authController.sessionHeartbeat);
 
 // Password reset routes
-router.post('/auth/forgot-password', passwordResetController.forgotPassword);
+router.post('/auth/forgot-password', createAuthLimiter(), passwordResetController.forgotPassword);
 router.post('/auth/reset-password', passwordResetController.resetPassword);
 
 // Profile email-change confirmation and account deletion


### PR DESCRIPTION
Summary:
Add dedicated 10 requests per 15 minutes rate limits to the login, register, and forgot-password endpoints.

Changes:
- extract auth limiter config into backend/src/middleware/rate-limit.ts
- keep the existing broader API limiter for the rest of the router
- apply dedicated auth limiters to /auth/login, /auth/register, and /auth/forgot-password
- add focused supertest coverage that verifies the 11th request returns 429 on each endpoint

Verification:
- backend/__tests__/auth-rate-limits.test.ts: 3/3 passing
- backend build still shows pre-existing generic db typing errors on develop; no new Step 5-specific compile issue found

Related Issues:
References #248