### PR TITLE
[STORY] Admin Restore Soft-Deleted Users

### DIFF
--- a/backend/__tests__/admin.integration.test.ts
+++ b/backend/__tests__/admin.integration.test.ts
@@ -9,6 +9,7 @@
  * - Admin can unlock a user account
  * - Admin cannot lock their own account (400)
  * - Admin can soft-delete a user
+ * - Admin can restore a soft-deleted user
  * - Admin cannot delete their own account (400)
  * - Admin can list all roles
  */
@@ -253,6 +254,55 @@ describe('Admin API — integration tests (#260 #279 #280)', () => {
       await adminController.deleteUser(req, res);
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toMatch(/already deleted/i);
+    });
+  });
+
+  // ── AC: Restore User ───────────────────────────────────────────────────────
+
+  describe('POST /api/admin/users/:id/restore', () => {
+    it('returns 200 and restores a soft-deleted user', async () => {
+      const db = getDatabase();
+      await db.run('UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?', [regularUserId]);
+
+      const res = makeRes();
+      const req = makeReq(
+        { id: String(regularUserId) },
+        {},
+        { id: adminUserId, email: 'admin@example.com', role_id: 3 },
+      );
+
+      await adminController.restoreUser(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(res.body.message).toMatch(/user restored/i);
+
+      const restoredUser = await db.get('SELECT deleted_at FROM users WHERE id = ?', [regularUserId]);
+      expect(restoredUser.deleted_at).toBeNull();
+    });
+
+    it('returns 400 when restoring a user that is not deleted', async () => {
+      const res = makeRes();
+      const req = makeReq(
+        { id: String(regularUserId) },
+        {},
+        { id: adminUserId, email: 'admin@example.com', role_id: 3 },
+      );
+
+      await adminController.restoreUser(req, res);
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toMatch(/not deleted/i);
+    });
+
+    it('returns 404 for a non-existent user', async () => {
+      const res = makeRes();
+      const req = makeReq(
+        { id: '99999' },
+        {},
+        { id: adminUserId, email: 'admin@example.com', role_id: 3 },
+      );
+
+      await adminController.restoreUser(req, res);
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toMatch(/user not found/i);
     });
   });
 

--- a/backend/src/controllers/admin-controller.ts
+++ b/backend/src/controllers/admin-controller.ts
@@ -81,6 +81,23 @@ export async function deleteUser(req: AuthRequest, res: Response): Promise<Respo
   return res.json({ message: 'User deleted.' });
 }
 
+/** POST /api/admin/users/:id/restore — restore a soft-deleted user */
+export async function restoreUser(req: AuthRequest, res: Response): Promise<Response> {
+  const db = getDatabase();
+  const { id } = req.params;
+
+  const user = await db.get('SELECT id, deleted_at FROM users WHERE id = ?', [id]);
+  if (!user) return res.status(404).json({ error: 'User not found.' });
+  if (!user.deleted_at) return res.status(400).json({ error: 'User is not deleted.' });
+
+  await db.run(
+    'UPDATE users SET deleted_at = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+    [id],
+  );
+
+  return res.json({ message: 'User restored.' });
+}
+
 /** GET /api/admin/roles — list all roles */
 export async function listRoles(_req: Request, res: Response): Promise<Response> {
   const db = getDatabase();

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -145,6 +145,7 @@ router.get('/admin/users', authenticateToken, authorizeRole(['Admin']), adminCon
 router.patch('/admin/users/:id/role', authenticateToken, authorizeRole(['Admin']), adminController.changeUserRole);
 router.patch('/admin/users/:id/lock', authenticateToken, authorizeRole(['Admin']), adminController.toggleLock);
 router.delete('/admin/users/:id', authenticateToken, authorizeRole(['Admin']), adminController.deleteUser);
+router.post('/admin/users/:id/restore', authenticateToken, authorizeRole(['Admin']), adminController.restoreUser);
 router.get('/admin/roles', authenticateToken, authorizeRole(['Admin']), adminController.listRoles);
 
 // ============ TASK ROUTES ============

--- a/frontend/src/components/admin/admin-page.tsx
+++ b/frontend/src/components/admin/admin-page.tsx
@@ -17,7 +17,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { LockRounded, LockOpenRounded, DeleteRounded } from '@mui/icons-material';
+import { LockRounded, LockOpenRounded, DeleteRounded, RestoreRounded } from '@mui/icons-material';
 import { api, ApiError } from '../../lib/api-client';
 import { useAuth } from '../../contexts/auth-context';
 
@@ -100,6 +100,18 @@ export default function AdminPage(): JSX.Element {
     }
   }
 
+  async function restoreUser(userId: number): Promise<void> {
+    setError(null);
+    setSuccess(null);
+    try {
+      await api.post(`/api/admin/users/${userId}/restore`);
+      setSuccess('User restored.');
+      await load();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to restore user.');
+    }
+  }
+
   if (loading) {
     return <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}><CircularProgress /></Box>;
   }
@@ -175,6 +187,16 @@ export default function AdminPage(): JSX.Element {
                             Delete
                           </Button>
                         </>
+                      )}
+                      {!isSelf && isDeleted && (
+                        <Button
+                          size="small"
+                          color="success"
+                          startIcon={<RestoreRounded />}
+                          onClick={() => restoreUser(u.id)}
+                        >
+                          Restore
+                        </Button>
                       )}
                     </Stack>
                   </TableCell>

--- a/src/__tests__/admin-user-management.test.tsx
+++ b/src/__tests__/admin-user-management.test.tsx
@@ -17,6 +17,7 @@ function makeUser(overrides: Partial<User> & { id: string }): User {
     emailConfirmed: true,
     createdAt: new Date('2026-01-01'),
     updatedAt: new Date('2026-01-01'),
+    deletedAt: null,
     ...overrides,
   };
 }
@@ -45,7 +46,15 @@ function mockRoleUpdate(user: User) {
   mockFetch.mockResolvedValueOnce({
     ok: true,
     status: 200,
-    json: async () => user,
+    json: async () => ({ message: 'Role updated.' }),
+  });
+}
+
+function mockRestoreUser() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ message: 'User restored.' }),
   });
 }
 
@@ -169,7 +178,8 @@ describe('AdminUserManagement', () => {
     fireEvent.change(screen.getByLabelText(/new role for organizer jane/i), { target: { value: 'Admin' } });
 
     const updatedUser = { ...orgUser, role: UserRole.Admin };
-    mockRoleUpdate(updatedUser);
+  mockRoleUpdate(updatedUser);
+  mockFetchUsers([updatedUser]);
 
     fireEvent.click(screen.getByRole('button', { name: /confirm changing role to admin/i }));
 
@@ -212,6 +222,36 @@ describe('AdminUserManagement', () => {
 
     expect(screen.getByText('Confirmed')).toBeInTheDocument();
     expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('restores a deleted user and shows active state again', async () => {
+    const deletedUser = makeUser({
+      id: 'deleted-1',
+      displayName: 'Deleted Dana',
+      email: 'deleted@test.com',
+      deletedAt: new Date('2026-02-01'),
+    });
+    const restoredUser = { ...deletedUser, deletedAt: null };
+
+    mockFetchUsers([deletedUser]);
+    render(<AdminUserManagement />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deleted Dana')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+    mockRestoreUser();
+    mockFetchUsers([restoredUser]);
+
+    fireEvent.click(screen.getByRole('button', { name: /restore deleted dana/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/deleted dana's account was restored/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Deleted')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change role for deleted dana/i })).toBeInTheDocument();
   });
 
   it('shows table headers with correct scope', async () => {

--- a/src/api/admin/admin-users.ts
+++ b/src/api/admin/admin-users.ts
@@ -2,6 +2,17 @@ import { User } from '../../types/user';
 import { UserRole } from '../../types/user-role';
 import { API_BASE_URL } from '../config';
 
+interface BackendAdminUser {
+  id: number;
+  email: string;
+  display_name: string;
+  role_name: UserRole;
+  email_verified: number;
+  deleted_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 async function adminRequest<T>(path: string, options: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     ...options,
@@ -23,15 +34,37 @@ async function adminRequest<T>(path: string, options: RequestInit): Promise<T> {
 }
 
 export async function fetchAllUsers(): Promise<User[]> {
-  return adminRequest<User[]>('/admin/users', { method: 'GET' });
+  const data = await adminRequest<User[] | { users: BackendAdminUser[] }>('/admin/users', { method: 'GET' });
+  const rows = Array.isArray(data) ? data : data.users;
+
+  return rows.map((row) => {
+    if ('displayName' in row) return row;
+
+    return {
+      id: String(row.id),
+      email: row.email,
+      displayName: row.display_name,
+      role: row.role_name,
+      emailConfirmed: Boolean(row.email_verified),
+      deletedAt: row.deleted_at ? new Date(row.deleted_at) : null,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    };
+  });
 }
 
 export async function updateUserRole(
   userId: string,
   role: UserRole,
-): Promise<User> {
-  return adminRequest<User>(`/admin/users/${encodeURIComponent(userId)}/role`, {
+): Promise<void> {
+  await adminRequest<{ message: string }>(`/admin/users/${encodeURIComponent(userId)}/role`, {
     method: 'PATCH',
-    body: JSON.stringify({ role }),
+    body: JSON.stringify({ role_id: role === UserRole.Admin ? 3 : role === UserRole.Organizer ? 2 : 1 }),
+  });
+}
+
+export async function restoreUser(userId: string): Promise<void> {
+  await adminRequest<{ message: string }>(`/admin/users/${encodeURIComponent(userId)}/restore`, {
+    method: 'POST',
   });
 }

--- a/src/components/admin-user-management/admin-user-management.css
+++ b/src/components/admin-user-management/admin-user-management.css
@@ -69,6 +69,10 @@
   color: #ed6c02;
 }
 
+.admin-user-management__status--deleted {
+  color: #c62828;
+}
+
 .admin-user-management__pagination {
   display: flex;
   justify-content: center;

--- a/src/components/admin-user-management/admin-user-management.tsx
+++ b/src/components/admin-user-management/admin-user-management.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { User } from '../../types/user';
 import { UserRole, USER_ROLES } from '../../types/user-role';
 import { useUserRole } from '../../hooks/use-user-role';
-import { fetchAllUsers, updateUserRole } from '../../api/admin/admin-users';
+import { fetchAllUsers, restoreUser, updateUserRole } from '../../api/admin/admin-users';
 import { UserTableRow } from './user-table-row';
 import { RoleChangeDialog } from './role-change-dialog';
 import './admin-user-management.css';
@@ -65,8 +65,8 @@ export function AdminUserManagement(): React.JSX.Element {
     if (!changeTarget) return;
     setChangeTarget(null);
     try {
-      const updated = await updateUserRole(changeTarget.userId, newRole);
-      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      await updateUserRole(changeTarget.userId, newRole);
+      await loadUsers();
       setFeedback({ type: 'success', message: `${changeTarget.userName}'s role updated to ${newRole}.` });
     } catch (err) {
       setFeedback({
@@ -74,7 +74,20 @@ export function AdminUserManagement(): React.JSX.Element {
         message: err instanceof Error ? err.message : 'Failed to update role.',
       });
     }
-  }, [changeTarget]);
+  }, [changeTarget, loadUsers]);
+
+  const handleRestore = useCallback(async (userId: string, userName: string) => {
+    try {
+      await restoreUser(userId);
+      await loadUsers();
+      setFeedback({ type: 'success', message: `${userName}'s account was restored.` });
+    } catch (err) {
+      setFeedback({
+        type: 'error',
+        message: err instanceof Error ? err.message : 'Failed to restore user.',
+      });
+    }
+  }, [loadUsers]);
 
   const cancelRoleChange = useCallback(() => { setChangeTarget(null); }, []);
 
@@ -158,7 +171,7 @@ export function AdminUserManagement(): React.JSX.Element {
               <tr><td colSpan={5} style={{ textAlign: 'center' }}>No users found.</td></tr>
             ) : (
               pageUsers.map((u) => (
-                <UserTableRow key={u.id} user={u} onRoleChange={handleRoleChange} />
+                <UserTableRow key={u.id} user={u} onRoleChange={handleRoleChange} onRestore={handleRestore} />
               ))
             )}
           </tbody>

--- a/src/components/admin-user-management/user-table-row.tsx
+++ b/src/components/admin-user-management/user-table-row.tsx
@@ -4,10 +4,14 @@ import { UserRole } from '../../types/user-role';
 interface UserTableRowProps {
   user: User;
   onRoleChange: (userId: string, userName: string, currentRole: UserRole) => void;
+  onRestore: (userId: string, userName: string) => void;
 }
 
-export function UserTableRow({ user, onRoleChange }: UserTableRowProps): React.JSX.Element {
-  const statusClass = user.emailConfirmed
+export function UserTableRow({ user, onRoleChange, onRestore }: UserTableRowProps): React.JSX.Element {
+  const isDeleted = Boolean(user.deletedAt);
+  const statusClass = isDeleted
+    ? 'admin-user-management__status--deleted'
+    : user.emailConfirmed
     ? 'admin-user-management__status--confirmed'
     : 'admin-user-management__status--pending';
 
@@ -18,21 +22,35 @@ export function UserTableRow({ user, onRoleChange }: UserTableRowProps): React.J
       <td>{user.role}</td>
       <td>
         <span className={statusClass}>
-          {user.emailConfirmed ? 'Confirmed' : 'Pending'}
+          {isDeleted ? 'Deleted' : user.emailConfirmed ? 'Confirmed' : 'Pending'}
         </span>
       </td>
       <td>
-        <button
-          onClick={() => onRoleChange(user.id, user.displayName, user.role)}
-          aria-label={`Change role for ${user.displayName}`}
-          style={{
-            padding: '4px 12px', fontSize: '0.85rem', cursor: 'pointer',
-            border: '1px solid #1976d2', borderRadius: 4,
-            background: '#fff', color: '#1976d2',
-          }}
-        >
-          Change Role
-        </button>
+        {isDeleted ? (
+          <button
+            onClick={() => onRestore(user.id, user.displayName)}
+            aria-label={`Restore ${user.displayName}`}
+            style={{
+              padding: '4px 12px', fontSize: '0.85rem', cursor: 'pointer',
+              border: '1px solid #2e7d32', borderRadius: 4,
+              background: '#fff', color: '#2e7d32',
+            }}
+          >
+            Restore
+          </button>
+        ) : (
+          <button
+            onClick={() => onRoleChange(user.id, user.displayName, user.role)}
+            aria-label={`Change role for ${user.displayName}`}
+            style={{
+              padding: '4px 12px', fontSize: '0.85rem', cursor: 'pointer',
+              border: '1px solid #1976d2', borderRadius: 4,
+              background: '#fff', color: '#1976d2',
+            }}
+          >
+            Change Role
+          </button>
+        )}
       </td>
     </tr>
   );

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -9,6 +9,7 @@ export interface User {
   displayName: string;
   role: UserRole;
   emailConfirmed: boolean;
+  deletedAt?: Date | null;
   profilePhotoUrl?: string;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
## Summary
- add a protected backend restore endpoint for soft-deleted users
- add restore coverage for backend admin tests and admin user management UI
- surface restore actions for deleted users in the admin pages

## Testing
- npm test -- admin.integration.test.ts
- npm test -- admin-user-management.test.tsx
- cd frontend && npm run build

References #298