### PR TITLE
fix(ci): resolve unified pipeline parse failure on push #292

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -164,11 +164,11 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.lint-and-typecheck.result }}" != "success" || \
-                "${{ needs.test-root.result }}" != "success" || \
-                "${{ needs.test-backend.result }}" != "success" || \
-                "${{ needs.test-frontend.result }}" != "success" || \
-                "${{ needs.build-check.result }}" != "success" ]]; then
+          if [[ "${{ needs['lint-and-typecheck'].result }}" != "success" || \
+                "${{ needs['test-root'].result }}" != "success" || \
+                "${{ needs['test-backend'].result }}" != "success" || \
+                "${{ needs['test-frontend'].result }}" != "success" || \
+                "${{ needs['build-check'].result }}" != "success" ]]; then
             echo "❌ One or more CI jobs failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary\n- fix invalid GitHub Actions expressions in CI Complete gate\n- use bracket notation for hyphenated job IDs in needs context\n- restore successful execution of CI - Unified Pipeline on push\n\nCloses #292