### PR TITLE
[TASK] Add seating chart editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Seating chart editor: tables now persist visual layout coordinates, can be dragged around the room canvas, and support visual guest reassignment by dragging guests between tables or back to the unassigned pool (#457)
 - Budget templates: create reusable budget templates with line-item categories and apply them to any event, with conflict-safe idempotent migrations (#438)
 - Shopping-to-budget sync: purchased shopping list items can be synced as budget expense entries; duplicate syncs are handled safely (amount updates if cost changed) (#439)
 - Shopping-to-budget sync: one-click sync of purchased shopping items into event expenses; duplicate-safe via source-tag in notes field (#439)
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `backend/__tests__/events-list-filter.test.ts` — 7 unit tests covering owner filter, tag filter, combined filters, no-auth guard, and error path
 
 ### Fixed
+- Frontend suite stability: analytics page tests now mock communication metrics consistently, and slower page smoke tests have explicit time budgets so the full Vitest run completes reliably under suite-wide load
 - Fixed frontend CSRF handling so login, password reset, uploads, and other mutating module actions reuse a valid token instead of refetching one per request, preventing proxy-path 403/429 failures in local Docker runs
 - Local backend startup now auto-loads `backend/.env` or repo `.env`, and falls back to the standard local PostgreSQL URL when no development `DATABASE_URL` is set
 - Added a dedicated `db-test` PostgreSQL Docker service on port `5433` so backend integration tests match the documented local test setup

--- a/backend/__tests__/seating-editor.test.ts
+++ b/backend/__tests__/seating-editor.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPostgresTestDatabase, type TestDatabase } from './helpers/postgres-test-db.js';
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS users (
+  id            SERIAL PRIMARY KEY,
+  email         TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  display_name  TEXT NOT NULL,
+  email_verified INTEGER DEFAULT 0,
+  role_id       INTEGER DEFAULT 1,
+  account_locked INTEGER DEFAULT 0,
+  login_attempts INTEGER DEFAULT 0,
+  created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at    TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS events (
+  id          SERIAL PRIMARY KEY,
+  title       TEXT NOT NULL,
+  date        TEXT NOT NULL DEFAULT '',
+  location    TEXT NOT NULL DEFAULT '',
+  capacity    INTEGER,
+  status      TEXT DEFAULT 'Draft',
+  created_by  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at  TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS event_members (
+  event_id    INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role        TEXT DEFAULT 'editor',
+  PRIMARY KEY (event_id, user_id)
+);
+CREATE TABLE IF NOT EXISTS rsvps (
+  id          SERIAL PRIMARY KEY,
+  event_id    INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  guests      INTEGER DEFAULT 1,
+  status      TEXT DEFAULT 'Pending',
+  notes       TEXT,
+  source      TEXT DEFAULT 'public',
+  checked_in  BOOLEAN DEFAULT FALSE,
+  checked_in_at TIMESTAMP,
+  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(event_id, email)
+);
+CREATE TABLE IF NOT EXISTS seating_tables (
+  id SERIAL PRIMARY KEY,
+  event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  capacity INTEGER DEFAULT 8,
+  layout_x INTEGER,
+  layout_y INTEGER,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS seating_assignments (
+  table_id INTEGER NOT NULL REFERENCES seating_tables(id) ON DELETE CASCADE,
+  rsvp_id INTEGER NOT NULL REFERENCES rsvps(id) ON DELETE CASCADE,
+  PRIMARY KEY (table_id, rsvp_id)
+);
+`;
+
+let testDb: TestDatabase;
+
+vi.mock('../src/db/database.js', () => ({
+  getDatabase: () => testDb,
+  initializeDatabase: async () => testDb,
+}));
+
+import { assignGuest, createTable, listTables, updateTableLayout } from '../src/controllers/seating-controller.js';
+
+function makeRes() {
+  const res: {
+    statusCode: number;
+    body: unknown;
+    status: (code: number) => typeof res;
+    json: (data: unknown) => typeof res;
+  } = {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.body = data; return this; },
+  };
+  return res;
+}
+
+function makeReq(
+  params: Record<string, string>,
+  body: Record<string, unknown> = {},
+  user = { id: 1, email: 'staff@test.com', role_id: 2 },
+) {
+  return { params, body, user } as unknown as import('express').Request;
+}
+
+async function seedUser(db: TestDatabase): Promise<number> {
+  const result = await db.run(
+    `INSERT INTO users (email, password_hash, display_name, email_verified, role_id)
+     VALUES ('owner@test.com', 'hash', 'Owner', 1, 2) RETURNING id`,
+  );
+  return result.lastID as number;
+}
+
+async function seedEvent(db: TestDatabase, userId: number): Promise<number> {
+  const result = await db.run(
+    `INSERT INTO events (title, date, location, created_by)
+     VALUES ('Fest', '2026-07-01', 'Park', ?) RETURNING id`,
+    [userId],
+  );
+  return result.lastID as number;
+}
+
+async function seedRsvp(db: TestDatabase, eventId: number, email: string, name: string): Promise<number> {
+  const result = await db.run(
+    `INSERT INTO rsvps (event_id, name, email, guests, status)
+     VALUES (?, ?, ?, 1, 'Going') RETURNING id`,
+    [eventId, name, email],
+  );
+  return result.lastID as number;
+}
+
+describe('seating editor controllers — issue #457', () => {
+  beforeEach(async () => {
+    testDb = await createPostgresTestDatabase(SCHEMA_SQL);
+  });
+
+  afterEach(async () => {
+    await testDb.close();
+  });
+
+  it('creates tables with default persisted layout coordinates', async () => {
+    const userId = await seedUser(testDb);
+    const eventId = await seedEvent(testDb, userId);
+
+    const req = makeReq({ eventId: String(eventId) }, { name: 'VIP Table', capacity: 6 }, {
+      id: userId,
+      email: 'owner@test.com',
+      role_id: 2,
+    });
+    const res = makeRes();
+
+    await createTable(req, res as unknown as import('express').Response);
+
+    expect(res.statusCode).toBe(201);
+    const body = res.body as { table: { layout_x: number; layout_y: number } };
+    expect(body.table.layout_x).toBeGreaterThanOrEqual(0);
+    expect(body.table.layout_y).toBeGreaterThanOrEqual(0);
+  });
+
+  it('persists dragged table coordinates through the layout update endpoint', async () => {
+    const userId = await seedUser(testDb);
+    const eventId = await seedEvent(testDb, userId);
+    const table = await testDb.run(
+      `INSERT INTO seating_tables (event_id, name, capacity, layout_x, layout_y)
+       VALUES (?, 'VIP Table', 6, 32, 32) RETURNING id`,
+      [eventId],
+    );
+
+    const req = makeReq(
+      { eventId: String(eventId), tableId: String(table.lastID) },
+      { layout_x: 244, layout_y: 188 },
+      { id: userId, email: 'owner@test.com', role_id: 2 },
+    );
+    const res = makeRes();
+
+    await updateTableLayout(req, res as unknown as import('express').Response);
+
+    expect(res.statusCode).toBe(200);
+    const row = await testDb.get<{ layout_x: number; layout_y: number }>(
+      'SELECT layout_x, layout_y FROM seating_tables WHERE id = ?',
+      [table.lastID],
+    );
+    expect(row).toEqual({ layout_x: 244, layout_y: 188 });
+  });
+
+  it('lists tables with stored coordinates and assigned guests', async () => {
+    const userId = await seedUser(testDb);
+    const eventId = await seedEvent(testDb, userId);
+    const table = await testDb.run(
+      `INSERT INTO seating_tables (event_id, name, capacity, layout_x, layout_y)
+       VALUES (?, 'VIP Table', 6, 120, 80) RETURNING id`,
+      [eventId],
+    );
+    const rsvpId = await seedRsvp(testDb, eventId, 'jane@test.com', 'Jane Doe');
+
+    const assignReq = makeReq(
+      { eventId: String(eventId), tableId: String(table.lastID), rsvpId: String(rsvpId) },
+      {},
+      { id: userId, email: 'owner@test.com', role_id: 2 },
+    );
+    await assignGuest(assignReq, makeRes() as unknown as import('express').Response);
+
+    const req = makeReq({ eventId: String(eventId) }, {}, { id: userId, email: 'owner@test.com', role_id: 2 });
+    const res = makeRes();
+
+    await listTables(req, res as unknown as import('express').Response);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      tables: Array<{ layout_x: number; layout_y: number; guests: Array<{ rsvp_id: number }> }>;
+    };
+    expect(body.tables[0].layout_x).toBe(120);
+    expect(body.tables[0].layout_y).toBe(80);
+    expect(body.tables[0].guests).toHaveLength(1);
+    expect(body.tables[0].guests[0].rsvp_id).toBe(rsvpId);
+  });
+});

--- a/backend/src/controllers/seating-controller.ts
+++ b/backend/src/controllers/seating-controller.ts
@@ -7,6 +7,8 @@ interface SeatingTable {
   event_id: number;
   name: string;
   capacity: number;
+  layout_x: number | null;
+  layout_y: number | null;
   created_at: string;
 }
 
@@ -86,9 +88,18 @@ export async function createTable(req: Request, res: Response): Promise<Response
   );
   if (!event) return res.status(404).json({ error: 'Event not found.' });
 
+  const layoutSeed = await db.get<{ count: number }>(
+    'SELECT COUNT(*) AS count FROM seating_tables WHERE event_id = ?',
+    [eventId],
+  );
+  const existingCount = layoutSeed?.count ?? 0;
+  const layoutX = 32 + (existingCount % 3) * 240;
+  const layoutY = 32 + Math.floor(existingCount / 3) * 180;
+
   const result = await db.run(
-    `INSERT INTO seating_tables (event_id, name, capacity) VALUES (?, ?, ?) RETURNING id`,
-    [eventId, name.trim(), cap],
+    `INSERT INTO seating_tables (event_id, name, capacity, layout_x, layout_y)
+     VALUES (?, ?, ?, ?, ?) RETURNING id`,
+    [eventId, name.trim(), cap, layoutX, layoutY],
   );
 
   const table = await db.get<SeatingTable>(
@@ -97,6 +108,44 @@ export async function createTable(req: Request, res: Response): Promise<Response
   );
 
   return res.status(201).json({ table });
+}
+
+/** PATCH /api/events/:eventId/seating/tables/:tableId/layout */
+export async function updateTableLayout(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { tableId, eventId } = req.params;
+  const { layout_x, layout_y } = req.body as {
+    layout_x?: number | string;
+    layout_y?: number | string;
+  };
+
+  const ok = await assertEventAccess(authReq, res, eventId);
+  if (!ok) return res as Response;
+
+  const nextX = Number(layout_x);
+  const nextY = Number(layout_y);
+  if (!Number.isFinite(nextX) || !Number.isFinite(nextY) || nextX < 0 || nextY < 0) {
+    return res.status(400).json({ error: 'Layout coordinates must be non-negative numbers.' });
+  }
+
+  const table = await db.get<Pick<SeatingTable, 'id'>>(
+    'SELECT id FROM seating_tables WHERE id = ? AND event_id = ?',
+    [tableId, eventId],
+  );
+  if (!table) return res.status(404).json({ error: 'Table not found.' });
+
+  await db.run(
+    'UPDATE seating_tables SET layout_x = ?, layout_y = ? WHERE id = ?',
+    [Math.round(nextX), Math.round(nextY), tableId],
+  );
+
+  const updatedTable = await db.get<SeatingTable>(
+    'SELECT * FROM seating_tables WHERE id = ?',
+    [tableId],
+  );
+
+  return res.json({ table: updatedTable });
 }
 
 /** DELETE /api/events/:eventId/seating/tables/:tableId */

--- a/backend/src/controllers/seating-controller.ts
+++ b/backend/src/controllers/seating-controller.ts
@@ -93,8 +93,8 @@ export async function createTable(req: Request, res: Response): Promise<Response
     [eventId],
   );
   const existingCount = layoutSeed?.count ?? 0;
-  const layoutX = 32 + (existingCount % 3) * 240;
-  const layoutY = 32 + Math.floor(existingCount / 3) * 180;
+  const layoutX = 32 + (existingCount % 3) * 300;
+  const layoutY = 32 + Math.floor(existingCount / 3) * 210;
 
   const result = await db.run(
     `INSERT INTO seating_tables (event_id, name, capacity, layout_x, layout_y)

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -515,9 +515,14 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
       event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
       name TEXT NOT NULL,
       capacity INTEGER DEFAULT 8,
+      layout_x INTEGER,
+      layout_y INTEGER,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `);
+
+  await db.exec(`ALTER TABLE seating_tables ADD COLUMN IF NOT EXISTS layout_x INTEGER`);
+  await db.exec(`ALTER TABLE seating_tables ADD COLUMN IF NOT EXISTS layout_y INTEGER`);
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS seating_assignments (

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -339,6 +339,7 @@ router.delete('/events/:eventId/timeline/:id', authenticateToken, timelineContro
 // ============ SEATING ROUTES — issues #386 #387 ============
 router.get('/events/:eventId/seating/tables', authenticateToken, seatingController.listTables);
 router.post('/events/:eventId/seating/tables', authenticateToken, seatingController.createTable);
+router.patch('/events/:eventId/seating/tables/:tableId/layout', authenticateToken, seatingController.updateTableLayout);
 router.delete('/events/:eventId/seating/tables/:tableId', authenticateToken, seatingController.deleteTable);
 router.post('/events/:eventId/seating/tables/:tableId/assign/:rsvpId', authenticateToken, seatingController.assignGuest);
 router.delete('/events/:eventId/seating/tables/:tableId/assign/:rsvpId', authenticateToken, seatingController.unassignGuest);

--- a/frontend/src/components/seating/seating-page.tsx
+++ b/frontend/src/components/seating/seating-page.tsx
@@ -120,6 +120,8 @@ export function SeatingPage(): JSX.Element {
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const dragStateRef = useRef<ActiveTableDrag | null>(null);
   const latestTablesRef = useRef<SeatingTable[]>([]);
+  const pendingDragPositionRef = useRef<TablePosition | null>(null);
+  const dragFrameRef = useRef<number | null>(null);
 
   const [tables, setTables] = useState<SeatingTable[]>([]);
   const [rsvps, setRsvps] = useState<Rsvp[]>([]);
@@ -251,6 +253,18 @@ export function SeatingPage(): JSX.Element {
     }
   };
 
+  const updateDraggedTablePosition = useCallback((tableId: number, position: TablePosition) => {
+    setTables((prev) => {
+      const next = prev.map((table) =>
+        table.id === tableId
+          ? { ...table, layout_x: position.x, layout_y: position.y }
+          : table,
+      );
+      latestTablesRef.current = next;
+      return next;
+    });
+  }, []);
+
   const persistTableLayout = useCallback(async (tableId: number) => {
     if (!eventId) return;
 
@@ -279,34 +293,45 @@ export function SeatingPage(): JSX.Element {
   useEffect(() => {
     if (draggingTableId == null) return;
 
+    const flushPendingDragPosition = () => {
+      const dragState = dragStateRef.current;
+      const pendingPosition = pendingDragPositionRef.current;
+      dragFrameRef.current = null;
+      if (!dragState || !pendingPosition) return;
+      updateDraggedTablePosition(dragState.tableId, pendingPosition);
+      pendingDragPositionRef.current = null;
+    };
+
     const handlePointerMove = (event: PointerEvent) => {
       const dragState = dragStateRef.current;
       const canvas = canvasRef.current;
       if (!dragState || !canvas) return;
 
       const canvasRect = canvas.getBoundingClientRect();
-      const nextX = clamp(
-        Math.round(event.clientX - canvasRect.left - dragState.offsetX),
-        0,
-        canvasRect.width - TABLE_WIDTH,
-      );
-      const nextY = clamp(
-        Math.round(event.clientY - canvasRect.top - dragState.offsetY),
-        0,
-        canvasRect.height - TABLE_HEIGHT,
-      );
-
-      setTables((prev) =>
-        prev.map((table) =>
-          table.id === dragState.tableId
-            ? { ...table, layout_x: nextX, layout_y: nextY }
-            : table,
+      pendingDragPositionRef.current = {
+        x: clamp(
+          Math.round(event.clientX - canvasRect.left - dragState.offsetX),
+          0,
+          canvasRect.width - TABLE_WIDTH,
         ),
-      );
+        y: clamp(
+          Math.round(event.clientY - canvasRect.top - dragState.offsetY),
+          0,
+          canvasRect.height - TABLE_HEIGHT,
+        ),
+      };
+
+      if (dragFrameRef.current == null) {
+        dragFrameRef.current = window.requestAnimationFrame(flushPendingDragPosition);
+      }
     };
 
     const handlePointerUp = () => {
       const dragState = dragStateRef.current;
+      if (dragFrameRef.current != null) {
+        window.cancelAnimationFrame(dragFrameRef.current);
+        flushPendingDragPosition();
+      }
       dragStateRef.current = null;
       setDraggingTableId(null);
       if (dragState) {
@@ -320,8 +345,13 @@ export function SeatingPage(): JSX.Element {
     return () => {
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
+      if (dragFrameRef.current != null) {
+        window.cancelAnimationFrame(dragFrameRef.current);
+        dragFrameRef.current = null;
+      }
+      pendingDragPositionRef.current = null;
     };
-  }, [draggingTableId, persistTableLayout]);
+  }, [draggingTableId, persistTableLayout, updateDraggedTablePosition]);
 
   const handleTablePointerDown = (tableId: number) => (event: React.PointerEvent<HTMLButtonElement>) => {
     const canvas = canvasRef.current;
@@ -485,7 +515,7 @@ export function SeatingPage(): JSX.Element {
                 <Box
                   ref={canvasRef}
                   data-testid="seating-layout-canvas"
-                  role="application"
+                  role="region"
                   aria-label="Seating layout editor"
                   sx={{
                     position: 'relative',

--- a/frontend/src/components/seating/seating-page.tsx
+++ b/frontend/src/components/seating/seating-page.tsx
@@ -6,7 +6,7 @@
  * Left panel: seating tables with assigned guest chips.
  * Right panel: unassigned RSVPs eligible for assignment.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -19,9 +19,11 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Grid,
   IconButton,
   MenuItem,
+  Paper,
   Select,
   SelectChangeEvent,
   Skeleton,
@@ -30,7 +32,12 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { AddRounded, DeleteRounded, PersonRemoveRounded } from '@mui/icons-material';
+import {
+  AddRounded,
+  DeleteRounded,
+  DragIndicatorRounded,
+  PersonRemoveRounded,
+} from '@mui/icons-material';
 import { useParams } from 'react-router-dom';
 import * as guestService from '../../services/guest-service';
 import type { Rsvp, SeatingTable } from '../../services/guest-service';
@@ -41,10 +48,78 @@ interface CreateTableForm {
   capacity: string;
 }
 
+interface DragGuestPayload {
+  rsvpId: number;
+  fromTableId: number | null;
+}
+
+interface TablePosition {
+  x: number;
+  y: number;
+}
+
+interface ActiveTableDrag {
+  tableId: number;
+  offsetX: number;
+  offsetY: number;
+}
+
 const FORM_DEFAULT: CreateTableForm = { name: '', capacity: '8' };
+const TABLE_WIDTH = 260;
+const TABLE_HEIGHT = 190;
+const LAYOUT_WIDTH = 960;
+const LAYOUT_HEIGHT = 560;
+
+function getFallbackPosition(index: number): TablePosition {
+  return {
+    x: 32 + (index % 3) * 300,
+    y: 32 + Math.floor(index / 3) * 210,
+  };
+}
+
+function getTablePosition(table: SeatingTable, index: number): TablePosition {
+  if (table.layout_x != null && table.layout_y != null) {
+    return { x: table.layout_x, y: table.layout_y };
+  }
+  return getFallbackPosition(index);
+}
+
+function normaliseTables(nextTables: SeatingTable[]): SeatingTable[] {
+  return nextTables.map((table, index) => {
+    const position = getTablePosition(table, index);
+    return {
+      ...table,
+      layout_x: position.x,
+      layout_y: position.y,
+    };
+  });
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function parseGuestDragPayload(raw: string): DragGuestPayload | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<DragGuestPayload>;
+    if (typeof parsed.rsvpId !== 'number') return null;
+    if (parsed.fromTableId !== null && parsed.fromTableId !== undefined && typeof parsed.fromTableId !== 'number') {
+      return null;
+    }
+    return {
+      rsvpId: parsed.rsvpId,
+      fromTableId: parsed.fromTableId ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
 
 export function SeatingPage(): JSX.Element {
   const { id: eventId } = useParams<{ id: string }>();
+  const canvasRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<ActiveTableDrag | null>(null);
+  const latestTablesRef = useRef<SeatingTable[]>([]);
 
   const [tables, setTables] = useState<SeatingTable[]>([]);
   const [rsvps, setRsvps] = useState<Rsvp[]>([]);
@@ -54,6 +129,8 @@ export function SeatingPage(): JSX.Element {
   const [form, setForm] = useState<CreateTableForm>(FORM_DEFAULT);
   const [formError, setFormError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [draggingTableId, setDraggingTableId] = useState<number | null>(null);
+  const [savingLayoutTableId, setSavingLayoutTableId] = useState<number | null>(null);
 
   const loadAll = useCallback(async () => {
     if (!eventId) return;
@@ -64,7 +141,7 @@ export function SeatingPage(): JSX.Element {
         guestService.listTables(eventId),
         guestService.listRsvps(eventId),
       ]);
-      setTables(tablesData);
+      setTables(normaliseTables(tablesData));
       setRsvps(rsvpsData);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load seating data.');
@@ -76,6 +153,10 @@ export function SeatingPage(): JSX.Element {
   useEffect(() => {
     void loadAll();
   }, [loadAll]);
+
+  useEffect(() => {
+    latestTablesRef.current = tables;
+  }, [tables]);
 
   // Compute the set of assigned rsvp IDs across all tables
   const assignedIds = new Set(
@@ -111,7 +192,7 @@ export function SeatingPage(): JSX.Element {
         name: form.name.trim(),
         capacity: cap,
       });
-      setTables((prev) => [...prev, { ...newTable, guests: [] }]);
+      setTables((prev) => normaliseTables([...prev, { ...newTable, guests: [] }]));
       setCreateOpen(false);
     } catch (err) {
       setFormError(err instanceof ApiError ? err.message : 'Failed to create table.');
@@ -170,14 +251,192 @@ export function SeatingPage(): JSX.Element {
     }
   };
 
+  const persistTableLayout = useCallback(async (tableId: number) => {
+    if (!eventId) return;
+
+    const table = latestTablesRef.current.find((candidate) => candidate.id === tableId);
+    if (!table || table.layout_x == null || table.layout_y == null) return;
+
+    setSavingLayoutTableId(tableId);
+    try {
+      const updatedTable = await guestService.updateTableLayout(eventId, tableId, {
+        layout_x: table.layout_x,
+        layout_y: table.layout_y,
+      });
+      setTables((prev) =>
+        prev.map((candidate) =>
+          candidate.id === tableId ? { ...candidate, ...updatedTable, guests: candidate.guests } : candidate,
+        ),
+      );
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to save table layout.');
+      await loadAll();
+    } finally {
+      setSavingLayoutTableId((current) => (current === tableId ? null : current));
+    }
+  }, [eventId, loadAll]);
+
+  useEffect(() => {
+    if (draggingTableId == null) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const dragState = dragStateRef.current;
+      const canvas = canvasRef.current;
+      if (!dragState || !canvas) return;
+
+      const canvasRect = canvas.getBoundingClientRect();
+      const nextX = clamp(
+        Math.round(event.clientX - canvasRect.left - dragState.offsetX),
+        0,
+        canvasRect.width - TABLE_WIDTH,
+      );
+      const nextY = clamp(
+        Math.round(event.clientY - canvasRect.top - dragState.offsetY),
+        0,
+        canvasRect.height - TABLE_HEIGHT,
+      );
+
+      setTables((prev) =>
+        prev.map((table) =>
+          table.id === dragState.tableId
+            ? { ...table, layout_x: nextX, layout_y: nextY }
+            : table,
+        ),
+      );
+    };
+
+    const handlePointerUp = () => {
+      const dragState = dragStateRef.current;
+      dragStateRef.current = null;
+      setDraggingTableId(null);
+      if (dragState) {
+        void persistTableLayout(dragState.tableId);
+      }
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [draggingTableId, persistTableLayout]);
+
+  const handleTablePointerDown = (tableId: number) => (event: React.PointerEvent<HTMLButtonElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const tableIndex = tables.findIndex((table) => table.id === tableId);
+    const table = tables[tableIndex];
+    if (!table) return;
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const currentPosition = getTablePosition(table, tableIndex);
+    dragStateRef.current = {
+      tableId,
+      offsetX: event.clientX - canvasRect.left - currentPosition.x,
+      offsetY: event.clientY - canvasRect.top - currentPosition.y,
+    };
+    setDraggingTableId(tableId);
+  };
+
+  const handleGuestDragStart = (
+    event: React.DragEvent<HTMLElement>,
+    rsvpId: number,
+    fromTableId: number | null,
+  ) => {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ rsvpId, fromTableId } satisfies DragGuestPayload),
+    );
+  };
+
+  const handleGuestDrop = async (
+    event: React.DragEvent<HTMLElement>,
+    targetTableId: number | null,
+  ) => {
+    event.preventDefault();
+    const payload = parseGuestDragPayload(event.dataTransfer.getData('application/json'));
+    if (!payload || !eventId || payload.fromTableId === targetTableId) return;
+
+    try {
+      if (targetTableId == null) {
+        if (payload.fromTableId == null) return;
+        await guestService.unassignGuest(eventId, payload.fromTableId, payload.rsvpId);
+      } else {
+        await guestService.assignGuest(eventId, targetTableId, payload.rsvpId);
+      }
+      await loadAll();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to move guest.');
+    }
+  };
+
+  const renderGuestCard = (
+    guest: { id: number; name: string; email: string; status: string },
+    fromTableId: number | null,
+    tableName?: string,
+  ) => (
+    <Stack
+      key={`${fromTableId ?? 'pool'}-${guest.id}`}
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      sx={{ width: '100%' }}
+    >
+      <Box
+        draggable
+        data-testid={`draggable-guest-${guest.id}`}
+        onDragStart={(event) => handleGuestDragStart(event, guest.id, fromTableId)}
+        sx={{
+          flex: 1,
+          px: 1.25,
+          py: 1,
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+          cursor: 'grab',
+        }}
+        aria-label={tableName ? `${guest.name} assigned to ${tableName}` : `${guest.name} unassigned guest`}
+      >
+        <Typography variant="body2" fontWeight={600}>
+          {guest.name}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {guest.email} · {guest.status}
+        </Typography>
+      </Box>
+      {fromTableId != null && (
+        <Tooltip title={`Remove ${guest.name} from table`}>
+          <IconButton
+            size="small"
+            color="default"
+            onClick={() => void handleUnassign(fromTableId, guest.id)}
+            aria-label={`Remove ${guest.name} from table`}
+          >
+            <PersonRemoveRounded fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Stack>
+  );
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
     <Box sx={{ p: 3 }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
-        <Typography variant="h5" fontWeight={700}>
-          Seating Chart
-        </Typography>
+      <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2} sx={{ mb: 3 }}>
+        <Box>
+          <Typography variant="h5" fontWeight={700}>
+            Seating Chart Editor
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, maxWidth: 720 }}>
+            Drag tables to arrange the room, then drag guests between tables or back to the unassigned list.
+          </Typography>
+        </Box>
         <Button
           variant="contained"
           startIcon={<AddRounded />}
@@ -195,174 +454,244 @@ export function SeatingPage(): JSX.Element {
       )}
 
       <Grid container spacing={3}>
-        {/* Left panel — Tables */}
-        <Grid item xs={12} md={8}>
-          <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1.5 }}>
-            Tables ({tables.length})
-          </Typography>
-
-          {loading && (
-            <Stack spacing={2}>
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} variant="rectangular" height={120} sx={{ borderRadius: 2 }} />
-              ))}
+        <Grid item xs={12} lg={8}>
+          <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" spacing={1.5}>
+              <Box>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  Layout Editor
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Tables ({tables.length})
+                </Typography>
+              </Box>
+              <Chip
+                label={savingLayoutTableId != null ? 'Saving layout…' : 'Drag tables to reposition'}
+                color={savingLayoutTableId != null ? 'warning' : 'default'}
+                variant="outlined"
+              />
             </Stack>
-          )}
 
-          {!loading && tables.length === 0 && (
-            <Box
-              sx={{
-                p: 6,
-                textAlign: 'center',
-                color: 'text.secondary',
-                border: '1px dashed',
-                borderColor: 'divider',
-                borderRadius: 2,
-              }}
-            >
-              <Typography>No tables yet. Create one to start assigning seats.</Typography>
-            </Box>
-          )}
+            {loading && (
+              <Stack spacing={2} sx={{ mt: 2 }}>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} variant="rectangular" height={140} sx={{ borderRadius: 2 }} />
+                ))}
+              </Stack>
+            )}
 
-          {!loading && (
-            <Stack spacing={2}>
-              {tables.map((table) => (
-                <Card key={table.id} variant="outlined">
-                  <CardHeader
-                    title={table.name}
-                    subheader={`Capacity: ${table.guests.length} / ${table.capacity}`}
-                    action={
-                      <Tooltip title="Delete table">
-                        <IconButton
-                          size="small"
-                          color="error"
-                          onClick={() => void handleDeleteTable(table.id)}
-                          aria-label={`Delete table ${table.name}`}
-                        >
-                          <DeleteRounded fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                    }
-                  />
-                  <CardContent sx={{ pt: 0 }}>
-                    {/* Assigned guests chips */}
-                    <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: 1.5 }}>
-                      {table.guests.map((g) => (
-                        <Box
-                          key={g.rsvp_id}
-                          sx={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 0.5,
-                            px: 0.5,
-                            py: 0.25,
-                            border: '1px solid',
-                            borderColor: 'divider',
-                            borderRadius: 4,
-                          }}
-                        >
-                          <Chip
-                            label={g.name}
-                            size="small"
-                            aria-label={`${g.name} assigned to ${table.name}`}
-                          />
-                          <Tooltip title={`Remove ${g.name} from table`}>
-                            <IconButton
-                              size="small"
-                              color="default"
-                              onClick={() => void handleUnassign(table.id, g.rsvp_id)}
-                              aria-label={`Remove ${g.name} from table`}
-                            >
-                              <PersonRemoveRounded fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </Box>
-                      ))}
-                      {table.guests.length === 0 && (
-                        <Typography variant="caption" color="text.secondary">
-                          No guests assigned
-                        </Typography>
-                      )}
-                    </Stack>
-
-                    {/* Assign from unassigned */}
-                    {table.guests.length < table.capacity && unassigned.length > 0 && (
-                      <Select
-                        displayEmpty
-                        size="small"
-                        value=""
-                        onChange={(e: SelectChangeEvent) =>
-                          void handleAssign(table.id, Number(e.target.value))
-                        }
-                        inputProps={{ 'aria-label': `Assign guest to ${table.name}` }}
-                        sx={{ minWidth: 220 }}
-                        renderValue={() => 'Assign a guest…'}
-                      >
-                        {unassigned.map((r) => (
-                          <MenuItem key={r.id} value={r.id}>
-                            {r.name} — {r.status}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
-            </Stack>
-          )}
-        </Grid>
-
-        {/* Right panel — Unassigned guests */}
-        <Grid item xs={12} md={4}>
-          <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1.5 }}>
-            Unassigned ({unassigned.length})
-          </Typography>
-
-          {loading && (
-            <Stack spacing={1}>
-              {Array.from({ length: 5 }).map((_, i) => (
-                <Skeleton key={i} variant="text" />
-              ))}
-            </Stack>
-          )}
-
-          {!loading && unassigned.length === 0 && (
-            <Box
-              sx={{
-                p: 4,
-                textAlign: 'center',
-                color: 'text.secondary',
-                border: '1px dashed',
-                borderColor: 'divider',
-                borderRadius: 2,
-              }}
-            >
-              <Typography variant="body2">All guests have been assigned a seat.</Typography>
-            </Box>
-          )}
-
-          {!loading && (
-            <Stack spacing={1}>
-              {unassigned.map((r) => (
+            {!loading && (
+              <Box sx={{ mt: 2, overflowX: 'auto' }}>
                 <Box
-                  key={r.id}
+                  ref={canvasRef}
+                  data-testid="seating-layout-canvas"
+                  role="application"
+                  aria-label="Seating layout editor"
                   sx={{
-                    p: 1.5,
+                    position: 'relative',
+                    minWidth: LAYOUT_WIDTH,
+                    height: LAYOUT_HEIGHT,
+                    borderRadius: 3,
                     border: '1px solid',
                     borderColor: 'divider',
-                    borderRadius: 1.5,
+                    bgcolor: '#fcfaf5',
+                    backgroundImage: 'radial-gradient(circle at 1px 1px, rgba(25, 118, 210, 0.12) 1px, transparent 0)',
+                    backgroundSize: '24px 24px',
+                    overflow: 'hidden',
                   }}
                 >
-                  <Typography variant="body2" fontWeight={600}>
-                    {r.name}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {r.email} · {r.status}
-                  </Typography>
+                  {tables.length === 0 && (
+                    <Stack
+                      spacing={1}
+                      alignItems="center"
+                      justifyContent="center"
+                      sx={{
+                        position: 'absolute',
+                        inset: 0,
+                        color: 'text.secondary',
+                      }}
+                    >
+                      <Typography fontWeight={600}>No tables yet.</Typography>
+                      <Typography variant="body2">Create one to start designing the seating layout.</Typography>
+                    </Stack>
+                  )}
+
+                  {tables.map((table, index) => {
+                    const position = getTablePosition(table, index);
+                    return (
+                      <Card
+                        key={table.id}
+                        data-testid={`table-card-${table.id}`}
+                        variant="outlined"
+                        onDragOver={(event) => event.preventDefault()}
+                        onDrop={(event) => void handleGuestDrop(event, table.id)}
+                        sx={{
+                          position: 'absolute',
+                          left: position.x,
+                          top: position.y,
+                          width: TABLE_WIDTH,
+                          minHeight: TABLE_HEIGHT,
+                          borderRadius: 3,
+                          borderColor: draggingTableId === table.id ? 'primary.main' : 'divider',
+                          boxShadow: draggingTableId === table.id ? 6 : 2,
+                          zIndex: draggingTableId === table.id ? 2 : 1,
+                          transition: draggingTableId === table.id ? 'none' : 'box-shadow 120ms ease',
+                        }}
+                      >
+                        <CardHeader
+                          title={table.name}
+                          subheader={`Capacity: ${table.guests.length} / ${table.capacity}`}
+                          action={
+                            <Stack direction="row" spacing={0.5} alignItems="center">
+                              <Tooltip title="Drag to move table">
+                                <IconButton
+                                  size="small"
+                                  onPointerDown={handleTablePointerDown(table.id)}
+                                  aria-label={`Move ${table.name}`}
+                                >
+                                  <DragIndicatorRounded fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title="Delete table">
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => void handleDeleteTable(table.id)}
+                                  aria-label={`Delete table ${table.name}`}
+                                >
+                                  <DeleteRounded fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </Stack>
+                          }
+                        />
+                        <CardContent sx={{ pt: 0 }}>
+                          <Stack spacing={1} sx={{ mb: 1.5 }}>
+                            {table.guests.map((guest) =>
+                              renderGuestCard(
+                                {
+                                  id: guest.rsvp_id,
+                                  name: guest.name,
+                                  email: guest.email,
+                                  status: guest.status,
+                                },
+                                table.id,
+                                table.name,
+                              ),
+                            )}
+                            {table.guests.length === 0 && (
+                              <Typography variant="caption" color="text.secondary">
+                                Drop guests here or use the assignment menu below.
+                              </Typography>
+                            )}
+                          </Stack>
+
+                          <Divider sx={{ mb: 1.5 }} />
+
+                          {table.guests.length < table.capacity && unassigned.length > 0 && (
+                            <Select
+                              displayEmpty
+                              size="small"
+                              value=""
+                              onChange={(event: SelectChangeEvent) =>
+                                void handleAssign(table.id, Number(event.target.value))
+                              }
+                              inputProps={{ 'aria-label': `Assign guest to ${table.name}` }}
+                              fullWidth
+                              renderValue={() => 'Assign a guest…'}
+                            >
+                              {unassigned.map((guest) => (
+                                <MenuItem key={guest.id} value={guest.id}>
+                                  {guest.name} — {guest.status}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          )}
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
                 </Box>
-              ))}
-            </Stack>
-          )}
+              </Box>
+            )}
+          </Paper>
+        </Grid>
+
+        <Grid item xs={12} lg={4}>
+          <Stack spacing={2}>
+            <Card
+              variant="outlined"
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => void handleGuestDrop(event, null)}
+              sx={{ borderRadius: 3 }}
+            >
+              <CardHeader
+                title="Unassigned Guests"
+                subheader={
+                  unassigned.length === 0
+                    ? 'Everyone is seated.'
+                    : `${unassigned.length} guests waiting for a seat`
+                }
+              />
+              <CardContent>
+                {loading && (
+                  <Stack spacing={1}>
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <Skeleton key={i} variant="text" />
+                    ))}
+                  </Stack>
+                )}
+
+                {!loading && unassigned.length === 0 && (
+                  <Box
+                    sx={{
+                      p: 3,
+                      textAlign: 'center',
+                      color: 'text.secondary',
+                      border: '1px dashed',
+                      borderColor: 'divider',
+                      borderRadius: 2,
+                    }}
+                  >
+                    <Typography variant="body2">All guests have been assigned a seat.</Typography>
+                  </Box>
+                )}
+
+                {!loading && unassigned.length > 0 && (
+                  <Stack spacing={1.25}>
+                    {unassigned.map((guest) =>
+                      renderGuestCard(
+                        {
+                          id: guest.id,
+                          name: guest.name,
+                          email: guest.email,
+                          status: guest.status,
+                        },
+                        null,
+                      ),
+                    )}
+                  </Stack>
+                )}
+              </CardContent>
+            </Card>
+
+            <Paper variant="outlined" sx={{ p: 2, borderRadius: 3 }}>
+              <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>
+                Editing Tips
+              </Typography>
+              <Stack spacing={0.75}>
+                <Typography variant="body2" color="text.secondary">
+                  Drag a table handle to reposition it on the room layout.
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Drag a guest onto a table to seat them or onto the unassigned list to remove them.
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  The assignment menu remains available for quick keyboard-friendly changes.
+                </Typography>
+              </Stack>
+            </Paper>
+          </Stack>
         </Grid>
       </Grid>
 

--- a/frontend/src/services/guest-service.ts
+++ b/frontend/src/services/guest-service.ts
@@ -118,6 +118,8 @@ export interface SeatingTable {
   event_id: number;
   name: string;
   capacity: number;
+  layout_x: number | null;
+  layout_y: number | null;
   created_at: string;
   guests: AssignedRsvp[];
 }
@@ -249,6 +251,19 @@ export async function createTable(
 ): Promise<SeatingTable> {
   const data = await api.post<{ table: SeatingTable }>(
     `/api/events/${eventId}/seating/tables`,
+    payload,
+  );
+  return data.table;
+}
+
+/** PATCH /api/events/:eventId/seating/tables/:tableId/layout */
+export async function updateTableLayout(
+  eventId: number | string,
+  tableId: number | string,
+  payload: { layout_x: number; layout_y: number },
+): Promise<SeatingTable> {
+  const data = await api.patch<{ table: SeatingTable }>(
+    `/api/events/${eventId}/seating/tables/${tableId}/layout`,
     payload,
   );
   return data.table;

--- a/frontend/test/analytics.test.tsx
+++ b/frontend/test/analytics.test.tsx
@@ -22,6 +22,7 @@ window.ResizeObserver = ResizeObserver;
 vi.mock('../src/services/analytics-service', () => ({
   getEventAnalytics: vi.fn(),
   getGlobalAnalytics: vi.fn(),
+  getCommunicationMetrics: vi.fn(),
   exportEventReport: vi.fn(),
 }));
 
@@ -56,6 +57,28 @@ const MOCK_ANALYTICS: analyticsService.EventAnalytics = {
   ],
 };
 
+const MOCK_COMMUNICATION_METRICS: analyticsService.CommunicationMetrics = {
+  totals: {
+    sent: 42,
+    failed: 2,
+    delivered: 40,
+    uniqueOpens: 25,
+    totalOpens: 31,
+    uniqueClicks: 8,
+    totalClicks: 11,
+    openRate: 0.625,
+    clickRate: 0.2,
+  },
+  byCampaign: [
+    {
+      campaignType: 'Invitation',
+      sent: 24,
+      opens: 18,
+      clicks: 6,
+    },
+  ],
+};
+
 function renderPage(eventId = '42'): ReturnType<typeof render> {
   return render(
     <MemoryRouter initialEntries={[`/events/${eventId}/analytics`]}>
@@ -69,6 +92,7 @@ function renderPage(eventId = '42'): ReturnType<typeof render> {
 describe('AnalyticsPage', () => {
   beforeEach(() => {
     mockedService.getEventAnalytics.mockResolvedValue(MOCK_ANALYTICS);
+    mockedService.getCommunicationMetrics.mockResolvedValue(MOCK_COMMUNICATION_METRICS);
     mockedService.exportEventReport.mockResolvedValue(undefined);
   });
 

--- a/frontend/test/expense-pdf-export.test.tsx
+++ b/frontend/test/expense-pdf-export.test.tsx
@@ -361,7 +361,7 @@ describe('BudgetPage — Export PDF button', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /export expense summary as pdf/i })).toBeInTheDocument();
     });
-  });
+  }, 15000);
 
   it('Export PDF button is disabled when both categories and expenses are empty', async () => {
     mockedService.listCategories.mockResolvedValue([]);

--- a/frontend/test/seating.test.tsx
+++ b/frontend/test/seating.test.tsx
@@ -23,6 +23,8 @@ const TABLES: SeatingTable[] = [
     event_id: 10,
     name: 'Table A',
     capacity: 4,
+    layout_x: 32,
+    layout_y: 32,
     created_at: '2026-01-01T00:00:00Z',
     guests: [{ rsvp_id: 2, name: 'Bob Jones', email: 'bob@test.com', status: 'Going' }],
   },
@@ -31,6 +33,8 @@ const TABLES: SeatingTable[] = [
     event_id: 10,
     name: 'Table B',
     capacity: 6,
+    layout_x: 332,
+    layout_y: 32,
     created_at: '2026-01-01T00:00:00Z',
     guests: [],
   },
@@ -77,6 +81,29 @@ function renderPage(eventId = '10') {
   );
 }
 
+function createDataTransfer(): DataTransfer {
+  const data = new Map<string, string>();
+  return {
+    dropEffect: 'move',
+    effectAllowed: 'all',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    clearData: (format?: string) => {
+      if (format) {
+        data.delete(format);
+        return;
+      }
+      data.clear();
+    },
+    getData: (format: string) => data.get(format) ?? '',
+    setData: (format: string, value: string) => {
+      data.set(format, value);
+    },
+    setDragImage: () => undefined,
+  } as DataTransfer;
+}
+
 describe('SeatingPage (#386)', () => {
   beforeEach(() => {
     mockedService.listTables.mockResolvedValue(TABLES);
@@ -88,10 +115,17 @@ describe('SeatingPage (#386)', () => {
       event_id: 10,
       name: 'Table C',
       capacity: 8,
+      layout_x: 32,
+      layout_y: 242,
       created_at: '2026-05-04T00:00:00Z',
       guests: [],
     });
     mockedService.deleteTable.mockResolvedValue(undefined);
+    mockedService.updateTableLayout.mockImplementation(async (_eventId, tableId, payload) => ({
+      ...(TABLES.find((table) => table.id === Number(tableId)) ?? TABLES[0]),
+      layout_x: payload.layout_x,
+      layout_y: payload.layout_y,
+    }));
   });
 
   it('renders table cards', async () => {
@@ -111,7 +145,7 @@ describe('SeatingPage (#386)', () => {
       expect(screen.getByText('Bob Jones')).toBeInTheDocument();
     });
 
-    // The chip should be inside the Table A card
+    // The draggable guest card should be inside the Table A card
     const tableACard = screen.getByText('Table A').closest('.MuiCard-root') ?? document.body;
     expect(tableACard).toHaveTextContent('Bob Jones');
   });
@@ -123,8 +157,8 @@ describe('SeatingPage (#386)', () => {
       expect(screen.getByText('Alice Smith')).toBeInTheDocument();
     });
 
-    // Alice is not in any table.guests so she appears in the unassigned panel
-    expect(screen.getByText('Unassigned (1)')).toBeInTheDocument();
+    expect(screen.getByText('Unassigned Guests')).toBeInTheDocument();
+    expect(screen.getByText('1 guests waiting for a seat')).toBeInTheDocument();
   });
 
   it('unassign button calls unassignGuest service', async () => {
@@ -164,6 +198,63 @@ describe('SeatingPage (#386)', () => {
 
     await waitFor(() => {
       expect(mockedService.createTable).toHaveBeenCalledWith('10', { name: 'Table C', capacity: 8 });
+    });
+  });
+
+  it('supports visually reassigning a guest by dropping them on another table', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draggable-guest-1')).toBeInTheDocument();
+    });
+
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(screen.getByTestId('draggable-guest-1'), { dataTransfer });
+    fireEvent.dragOver(screen.getByTestId('table-card-2'), { dataTransfer });
+    fireEvent.drop(screen.getByTestId('table-card-2'), { dataTransfer });
+
+    await waitFor(() => {
+      expect(mockedService.assignGuest).toHaveBeenCalledWith('10', 2, 1);
+    });
+  });
+
+  it('persists table layout after dragging a table handle', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /move table a/i })).toBeInTheDocument();
+    });
+
+    const canvas = screen.getByTestId('seating-layout-canvas');
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 960,
+      bottom: 560,
+      width: 960,
+      height: 560,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /move table a/i }), {
+      pointerId: 1,
+      clientX: 72,
+      clientY: 72,
+    });
+    fireEvent.pointerMove(window, { pointerId: 1, clientX: 360, clientY: 240 });
+    fireEvent.pointerUp(window, { pointerId: 1 });
+
+    await waitFor(() => {
+      expect(mockedService.updateTableLayout).toHaveBeenCalledWith(
+        '10',
+        1,
+        expect.objectContaining({
+          layout_x: expect.any(Number),
+          layout_y: expect.any(Number),
+        }),
+      );
     });
   });
 });

--- a/frontend/test/tasks-kanban.test.tsx
+++ b/frontend/test/tasks-kanban.test.tsx
@@ -113,7 +113,7 @@ describe('TasksKanbanPage', () => {
     expect(screen.getByRole('region', { name: /in progress column/i })).toBeTruthy();
     expect(screen.getByRole('region', { name: /blocked column/i })).toBeTruthy();
     expect(screen.getByRole('region', { name: /complete column/i })).toBeTruthy();
-  });
+  }, 15000);
 
   it('shows correct task counts per column', async () => {
     renderBoard();

--- a/frontend/test/timeline.test.tsx
+++ b/frontend/test/timeline.test.tsx
@@ -73,7 +73,7 @@ describe('TimelinePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /add activity/i }));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
-  });
+  }, 15000);
 
   it('submits a new activity', async () => {
     renderPage();

--- a/frontend/test/vendors.test.tsx
+++ b/frontend/test/vendors.test.tsx
@@ -83,7 +83,7 @@ describe('VendorsPage', () => {
     await userEvent.click(screen.getByRole('button', { name: /add vendor/i }));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByLabelText(/vendor name/i)).toBeInTheDocument();
-  });
+  }, 15000);
 
   it('submits a new vendor', async () => {
     renderPage();


### PR DESCRIPTION
## Summary
- add a visual seating chart editor with draggable table layout persistence
- support visual guest reassignment between tables and the unassigned pool while keeping existing seating CRUD intact
- fix frontend test issues uncovered during full validation so the branch is green end to end

## Validation
- frontend: npm test
- frontend: npm run build
- backend: npm test
- backend: npm run typecheck
- backend: npm run build
- backend: npm run lint
- root: npm test
- root: npm run build

Closes #457