### PR TITLE
ci: skip merge commits in commit-message validation #3

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -111,8 +111,9 @@ jobs:
         run: |
           echo "Validating commit messages..."
           
-          # Get all commits in this PR
-          COMMITS=$(git log --format="%H" $BASE_SHA..$HEAD_SHA)
+          # Get all non-merge commits in this PR. Merge commits are auto-generated
+          # by GitHub or `git merge` and cannot reliably carry issue references.
+          COMMITS=$(git log --format="%H" --no-merges $BASE_SHA..$HEAD_SHA)
           
           ERRORS=0
           


### PR DESCRIPTION
## Summary

- The "Validate Commit Messages" job in `.github/workflows/ci-pr-validation.yml` iterated *every* commit in `$BASE_SHA..$HEAD_SHA`, including auto-generated merge commits.
- Auto-generated merge commits (e.g. `Merge remote-tracking branch 'origin/develop' into feature/...`) cannot reliably include issue references, so any PR that absorbed `develop` would fail this gate even when all author-written commits were compliant.
- Switched the `git log` invocation to use `--no-merges` so only substantive commits are validated.

## Test plan

- [x] Workflow diff is a one-line change with rationale in comment
- [x] Issue reference (#3 — CI Validation Workflows) is closed but referenced for hierarchy and commit-msg gates
- [ ] CI runs "Validate Commit Messages" on this PR and passes
- [ ] CI runs "Validate Issue Hierarchy" on this PR and passes
- [ ] After merge, future feature PRs that sync from develop no longer trip the commit-message gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)