### PR TITLE
ci: tolerate existing PR in auto-draft-pr workflow #3

### DIFF
--- a/.github/workflows/auto-draft-pr.yml
+++ b/.github/workflows/auto-draft-pr.yml
@@ -70,10 +70,25 @@ jobs:
 
           echo "Creating draft PR: $PR_TITLE"
 
-          gh pr create \
+          set +e
+          CREATE_OUTPUT=$(gh pr create \
             --repo "${{ github.repository }}" \
             --head "$BRANCH" \
             --base develop \
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
-            --draft
+            --draft 2>&1)
+          CREATE_STATUS=$?
+          set -e
+
+          echo "$CREATE_OUTPUT"
+
+          if [[ $CREATE_STATUS -ne 0 ]]; then
+            # Race condition: a PR may have been created between the existence
+            # check and this step. Treat that as a success rather than failing.
+            if echo "$CREATE_OUTPUT" | grep -qiE "a pull request already exists"; then
+              echo "PR already exists — nothing to do."
+              exit 0
+            fi
+            exit $CREATE_STATUS
+          fi


### PR DESCRIPTION
## Summary

- The "Create draft PR to develop" job in `.github/workflows/auto-draft-pr.yml` had a race condition: an existence check ran in one step, then `gh pr create` ran in a later step. If a developer manually created the PR in between (as just happened on #654), the create call failed with `A pull request already exists for …`, producing a spurious red ✗.
- Wrap `gh pr create` to capture stderr; if the failure message matches the "already exists" case, exit 0. Any other failure is still surfaced.

Closes #3

## Test plan

- [x] CI on this PR runs through cleanly
- [ ] After merge, manually-created PRs that pre-empt the workflow no longer produce a red ✗ on the push

🤖 Generated with [Claude Code](https://claude.com/claude-code)