### PR TITLE
feat(auth): close Entra/RBAC security gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Entra group-to-role mapping with precedence (`Admin > Organizer > Collaborator > Guest > Viewer`) via configurable env vars (`ENTRA_GROUP_ADMINS`, `ENTRA_GROUP_ORGANIZERS`, `ENTRA_GROUP_COLLABORATORS`, `ENTRA_GROUP_GUESTS`, `ENTRA_GROUP_VIEWERS`) and callback-time role assignment for Entra SSO logins
+- Event member role normalization to BRD event roles (`Owner`, `Co-Organizer`, `Helper`, `Guest`) with dynamic precedence checks in shared event access utilities
+- RBAC permission-change audit trail coverage for role creation, role assignment, and permission add/remove controller operations
 - **UI Overhaul — Professional Design System**: Comprehensive MUI theme rewrite with enterprise-grade design tokens, Inter + Plus Jakarta Sans typography, refined color palette (`#4f46e5` primary), and consistent component overrides for buttons, inputs, cards, tables, dialogs, and more (`frontend/src/theme/app-theme.ts`)
 - **UI Overhaul — Collapsible Sidebar Navigation**: Full rewrite of `app-nav.tsx` with collapsible drawer (256px ↔ 68px), grouped nav sections ("Event Hub", "Workspace") with expand/collapse, dark sidebar background, user avatar, dark/light mode toggle, and smooth CSS transitions
 - **UI Overhaul — PageLayout Component**: New `frontend/src/components/layout/page-layout.tsx` wrapper providing consistent sticky header with breadcrumbs, page title/subtitle, and actions slot across all authenticated pages

--- a/backend/__tests__/entra-auth.test.ts
+++ b/backend/__tests__/entra-auth.test.ts
@@ -116,7 +116,14 @@ const SCHEMA = `
     name TEXT UNIQUE NOT NULL
   );
 
-  INSERT INTO roles (id, name) VALUES (1, 'Attendee') ON CONFLICT DO NOTHING;
+  INSERT INTO roles (id, name) VALUES
+    (1, 'Attendee'),
+    (2, 'Organizer'),
+    (3, 'Admin'),
+    (4, 'Collaborator'),
+    (5, 'Guest'),
+    (6, 'Viewer')
+  ON CONFLICT DO NOTHING;
 `;
 
 beforeEach(async () => {
@@ -233,6 +240,45 @@ describe('POST /api/auth/entra/callback — identity mapping', () => {
     );
     expect(user?.entra_oid).toBe('entra-oid-link');
     expect(user?.auth_provider).toBe('entra');
+  });
+
+  it('maps Entra groups to highest-precedence app role', async () => {
+    process.env.ENTRA_GROUP_ADMINS = 'group-admin';
+    process.env.ENTRA_GROUP_ORGANIZERS = 'group-organizer';
+    process.env.ENTRA_GROUP_COLLABORATORS = 'group-collab';
+    process.env.ENTRA_GROUP_GUESTS = 'group-guest';
+    process.env.ENTRA_GROUP_VIEWERS = 'group-viewer';
+
+    vi.doMock('../src/utils/entra-token.js', () => ({
+      validateEntraIdToken: vi.fn().mockResolvedValue({
+        oid: 'entra-oid-admin',
+        email: 'groupuser@example.com',
+        name: 'Group User',
+        tid: 'test-tenant',
+        aud: 'test-client',
+        iss: 'https://login.microsoftonline.com/test-tenant/v2.0',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+        groups: ['group-collab', 'group-admin'],
+      }),
+    }));
+
+    const { handleEntraCallback } = await import('../src/controllers/entra-auth-controller.js');
+    const req = { body: { id_token: 'fake.jwt.token' } } as import('express').Request;
+    const res = makeRes();
+
+    await handleEntraCallback(req, res as unknown as import('express').Response);
+
+    const user = await testDb.get<{ role_id: number }>(
+      `SELECT role_id FROM users WHERE email = 'groupuser@example.com'`,
+    );
+    expect(user?.role_id).toBe(3); // Admin has precedence over collaborator
+
+    delete process.env.ENTRA_GROUP_ADMINS;
+    delete process.env.ENTRA_GROUP_ORGANIZERS;
+    delete process.env.ENTRA_GROUP_COLLABORATORS;
+    delete process.env.ENTRA_GROUP_GUESTS;
+    delete process.env.ENTRA_GROUP_VIEWERS;
   });
 
   it('returns 404 when Entra auth is disabled', async () => {

--- a/backend/__tests__/refresh-token-cookie.test.ts
+++ b/backend/__tests__/refresh-token-cookie.test.ts
@@ -158,5 +158,29 @@ describe('Refresh Token HttpOnly Cookie (#249 #267 #289 #290)', () => {
       expect(refreshRes.statusCode).toBe(200);
       expect(refreshRes.body).toHaveProperty('accessToken');
     });
+
+    it('does not return accessToken in production response body', async () => {
+      const previousNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      await seedVerifiedUser('produser@test.com', 'Pass1234');
+      const loginRes = makeRes();
+      await login(makeReq({ email: 'produser@test.com', password: 'Pass1234' }), loginRes);
+
+      const cookieToken = loginRes.cookies['refreshToken']?.value;
+      expect(cookieToken).toBeDefined();
+
+      const refreshRes = makeRes();
+      await refreshTokenEndpoint(makeReq({}, { refreshToken: cookieToken }), refreshRes);
+
+      expect(refreshRes.statusCode).toBe(200);
+      expect(refreshRes.body).not.toHaveProperty('accessToken');
+
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    });
   });
 });

--- a/backend/src/config/entra.ts
+++ b/backend/src/config/entra.ts
@@ -7,6 +7,14 @@ export interface EntraConfig {
   jwksUri: string;
 }
 
+export interface EntraGroupRoleConfig {
+  admins: string[];
+  organizers: string[];
+  collaborators: string[];
+  guests: string[];
+  viewers: string[];
+}
+
 export function isEntraEnabled(): boolean {
   return process.env.ENTRA_AUTH_ENABLED === 'true';
 }
@@ -43,4 +51,52 @@ export function validateEntraConfigAtStartup(): void {
   if (!isEntraEnabled()) return;
   getEntraConfig();
   console.log('[Entra] Configuration validated. Entra auth is enabled.');
+}
+
+function parseGroupList(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Optional mapping of Entra group object IDs to application roles.
+ *
+ * Env vars accept comma-separated Entra group IDs:
+ * - ENTRA_GROUP_ADMINS
+ * - ENTRA_GROUP_ORGANIZERS
+ * - ENTRA_GROUP_COLLABORATORS
+ * - ENTRA_GROUP_GUESTS
+ * - ENTRA_GROUP_VIEWERS
+ */
+export function getEntraGroupRoleConfig(): EntraGroupRoleConfig {
+  return {
+    admins: parseGroupList(process.env.ENTRA_GROUP_ADMINS),
+    organizers: parseGroupList(process.env.ENTRA_GROUP_ORGANIZERS),
+    collaborators: parseGroupList(process.env.ENTRA_GROUP_COLLABORATORS),
+    guests: parseGroupList(process.env.ENTRA_GROUP_GUESTS),
+    viewers: parseGroupList(process.env.ENTRA_GROUP_VIEWERS),
+  };
+}
+
+/**
+ * Resolves app role name from Entra groups using explicit precedence.
+ * Precedence: Admin > Organizer > Collaborator > Guest > Viewer.
+ */
+export function resolveRoleFromEntraGroups(groupIds: string[]): string | null {
+  if (!Array.isArray(groupIds) || groupIds.length === 0) {
+    return null;
+  }
+
+  const userGroups = new Set(groupIds);
+  const cfg = getEntraGroupRoleConfig();
+
+  if (cfg.admins.some((id) => userGroups.has(id))) return 'Admin';
+  if (cfg.organizers.some((id) => userGroups.has(id))) return 'Organizer';
+  if (cfg.collaborators.some((id) => userGroups.has(id))) return 'Collaborator';
+  if (cfg.guests.some((id) => userGroups.has(id))) return 'Guest';
+  if (cfg.viewers.some((id) => userGroups.has(id))) return 'Viewer';
+
+  return null;
 }

--- a/backend/src/controllers/auth-controller.ts
+++ b/backend/src/controllers/auth-controller.ts
@@ -449,10 +449,15 @@ export async function refreshTokenEndpoint(req: Request, res: Response): Promise
     severity: 'INFO',
   });
 
-  return res.status(200).json({
+  const payload: { message: string; accessToken?: string } = {
     message: 'Token refreshed successfully.',
-    accessToken: newAccessToken,
-  });
+  };
+
+  if (process.env.NODE_ENV !== 'production') {
+    payload.accessToken = newAccessToken;
+  }
+
+  return res.status(200).json(payload);
 }
 
 /**

--- a/backend/src/controllers/entra-auth-controller.ts
+++ b/backend/src/controllers/entra-auth-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import crypto from 'crypto';
-import { isEntraEnabled, getEntraConfig, isMfaRequired } from '../config/entra.js';
+import { isEntraEnabled, getEntraConfig, isMfaRequired, resolveRoleFromEntraGroups } from '../config/entra.js';
 import { validateEntraIdToken } from '../utils/entra-token.js';
 import { getDatabase } from '../db/database.js';
 import { generateTokens } from '../middleware/auth.js';
@@ -125,6 +125,13 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
 
   const db = getDatabase();
 
+  const requestedRoleName = resolveRoleFromEntraGroups(Array.isArray(claims.groups) ? claims.groups : []);
+  let requestedRoleId: number | null = null;
+  if (requestedRoleName) {
+    const role = await db.get<{ id: number }>('SELECT id FROM roles WHERE name = $1', [requestedRoleName]);
+    requestedRoleId = role?.id ?? null;
+  }
+
   let user = await db.get<UserRow>(
     'SELECT id, email, role_id, entra_oid FROM users WHERE entra_oid = $1 AND deleted_at IS NULL',
     [entraOid],
@@ -138,9 +145,17 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
 
     if (user) {
       await db.run(
-        `UPDATE users SET entra_oid = $1, auth_provider = 'entra', updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
-        [entraOid, user.id],
+        `UPDATE users
+         SET entra_oid = $1,
+             auth_provider = 'entra',
+             role_id = COALESCE($2, role_id),
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = $3`,
+        [entraOid, requestedRoleId, user.id],
       );
+      if (requestedRoleId !== null) {
+        user.role_id = requestedRoleId;
+      }
     }
   }
 
@@ -162,6 +177,11 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
       'SELECT id, email, role_id, entra_oid FROM users WHERE id = $1',
       [result.lastID],
     );
+
+    if (user && requestedRoleId !== null) {
+      await db.run('UPDATE users SET role_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2', [requestedRoleId, user.id]);
+      user.role_id = requestedRoleId;
+    }
   }
 
   if (!user) {

--- a/backend/src/controllers/event-members-controller.ts
+++ b/backend/src/controllers/event-members-controller.ts
@@ -6,6 +6,16 @@ interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
 }
 
+function normalizeIncomingEventRole(rawRole: string | undefined): 'Owner' | 'Co-Organizer' | 'Helper' | 'Guest' {
+  const normalized = (rawRole ?? '').trim().toLowerCase();
+  if (!normalized) return 'Helper';
+  if (normalized === 'owner') return 'Owner';
+  if (normalized === 'co-organizer' || normalized === 'coorganizer') return 'Co-Organizer';
+  if (normalized === 'helper' || normalized === 'member') return 'Helper';
+  if (normalized === 'guest') return 'Guest';
+  throw new Error('Invalid event role. Allowed values: Owner, Co-Organizer, Helper, Guest.');
+}
+
 /** GET /api/events/:eventId/members */
 export async function listMembers(req: Request, res: Response): Promise<Response> {
   const authReq = req as AuthRequest;
@@ -56,11 +66,18 @@ export async function addMember(req: Request, res: Response): Promise<Response> 
   const user = await db.get('SELECT id FROM users WHERE id = $1 AND deleted_at IS NULL', [numericUserId]);
   if (!user) return res.status(404).json({ error: 'User not found.' });
 
+  let eventRole: 'Owner' | 'Co-Organizer' | 'Helper' | 'Guest';
+  try {
+    eventRole = normalizeIncomingEventRole(role);
+  } catch (error) {
+    return res.status(400).json({ error: error instanceof Error ? error.message : 'Invalid event role.' });
+  }
+
   await db.run(
     `INSERT INTO event_members (event_id, user_id, role)
      VALUES ($1, $2, $3)
      ON CONFLICT (event_id, user_id) DO UPDATE SET role = EXCLUDED.role`,
-    [eventId, numericUserId, role || 'Member'],
+    [eventId, numericUserId, eventRole],
   );
 
   return res.status(201).json({ message: 'Member added.' });

--- a/backend/src/controllers/rbac-controller.ts
+++ b/backend/src/controllers/rbac-controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { getDatabase } from '../db/database.js';
+import { logAuditEvent, AUDIT_ACTIONS } from '../utils/audit-log.js';
 
 interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
@@ -60,6 +61,19 @@ export async function createRole(req: AuthRequest, res: Response): Promise<Respo
     [name, description || ''],
   );
 
+  await logAuditEvent({
+    db,
+    userId: req.user?.id,
+    email: req.user?.email,
+    action: AUDIT_ACTIONS.ROLE_CHANGE,
+    description: `Role created: ${name}`,
+    ipAddress: req.ip,
+    targetType: 'role',
+    targetId: String(result.lastID),
+    context: { roleName: name },
+    severity: 'INFO',
+  });
+
   return res.status(201).json({ id: result.lastID, name, description });
 }
 
@@ -86,7 +100,21 @@ export async function assignRoleToUser(req: AuthRequest, res: Response): Promise
     return res.status(404).json({ error: 'User not found' });
   }
 
+  const previous = await db.get<{ role_id: number }>('SELECT role_id FROM users WHERE id = $1', [userId]);
   await db.run('UPDATE users SET role_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2', [roleId, userId]);
+
+  await logAuditEvent({
+    db,
+    userId: req.user?.id,
+    email: req.user?.email,
+    action: AUDIT_ACTIONS.ROLE_CHANGE,
+    description: `Assigned role ${roleId} to user ${userId}`,
+    ipAddress: req.ip,
+    targetType: 'user',
+    targetId: String(userId),
+    context: { previousRoleId: previous?.role_id ?? null, newRoleId: roleId },
+    severity: 'INFO',
+  });
 
   return res.status(200).json({ message: 'Role assigned successfully' });
 }
@@ -117,6 +145,19 @@ export async function addPermissionToRole(req: AuthRequest, res: Response): Prom
     [roleId, permissionId],
   );
 
+  await logAuditEvent({
+    db,
+    userId: req.user?.id,
+    email: req.user?.email,
+    action: AUDIT_ACTIONS.ROLE_CHANGE,
+    description: `Added permission ${permissionId} to role ${roleId}`,
+    ipAddress: req.ip,
+    targetType: 'role',
+    targetId: String(roleId),
+    context: { permissionId, operation: 'add-permission' },
+    severity: 'INFO',
+  });
+
   return res.status(201).json({ message: 'Permission added to role' });
 }
 
@@ -136,6 +177,19 @@ export async function removePermissionFromRole(req: AuthRequest, res: Response):
     'DELETE FROM role_permissions WHERE role_id = $1 AND permission_id = $2',
     [roleId, permissionId],
   );
+
+  await logAuditEvent({
+    db,
+    userId: req.user?.id,
+    email: req.user?.email,
+    action: AUDIT_ACTIONS.ROLE_CHANGE,
+    description: `Removed permission ${permissionId} from role ${roleId}`,
+    ipAddress: req.ip,
+    targetType: 'role',
+    targetId: String(roleId),
+    context: { permissionId, operation: 'remove-permission' },
+    severity: 'INFO',
+  });
 
   return res.status(200).json({ message: 'Permission removed from role' });
 }

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -1179,13 +1179,16 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
     CREATE TABLE IF NOT EXISTS event_members (
       event_id INTEGER NOT NULL,
       user_id INTEGER NOT NULL,
-      role TEXT DEFAULT 'Member',
+      role TEXT DEFAULT 'Helper',
       joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       PRIMARY KEY (event_id, user_id),
       FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     )
   `);
+
+  // Normalize legacy role labels to BRD role model.
+  await db.exec(`UPDATE event_members SET role = 'Helper' WHERE LOWER(COALESCE(role, '')) = 'member'`);
 
   // ── Vendor Management (BRD 3.6) ──────────────────────────────────────────
   await db.exec(`

--- a/backend/src/utils/entra-token.ts
+++ b/backend/src/utils/entra-token.ts
@@ -28,6 +28,8 @@ export interface EntraTokenClaims {
   nonce?: string;
   /** Authentication methods references — 'mfa' is present when MFA was completed (#568) */
   amr?: string[];
+  /** Optional Entra group object IDs for RBAC mapping. */
+  groups?: string[];
 }
 
 let _jwksCache: { keys: JwksKey[]; fetchedAt: number } | null = null;

--- a/backend/src/utils/event-access.ts
+++ b/backend/src/utils/event-access.ts
@@ -8,8 +8,31 @@ interface EventAccessRequest {
 interface EventAccessOptions {
   allowMembers?: boolean;
   ownerOnly?: boolean;
+  minEventRole?: EventMemberRole;
   notFoundMessage?: string;
   forbiddenMessage?: string;
+}
+
+export type EventMemberRole = 'Owner' | 'Co-Organizer' | 'Helper' | 'Guest';
+
+const EVENT_ROLE_WEIGHT: Record<EventMemberRole, number> = {
+  Owner: 4,
+  'Co-Organizer': 3,
+  Helper: 2,
+  Guest: 1,
+};
+
+function normalizeEventRole(role: string | null | undefined): EventMemberRole | null {
+  const value = (role ?? '').trim().toLowerCase();
+  if (value === 'owner') return 'Owner';
+  if (value === 'co-organizer' || value === 'coorganizer') return 'Co-Organizer';
+  if (value === 'helper' || value === 'member') return 'Helper';
+  if (value === 'guest') return 'Guest';
+  return null;
+}
+
+function hasMinimumEventRole(actual: EventMemberRole, required: EventMemberRole): boolean {
+  return EVENT_ROLE_WEIGHT[actual] >= EVENT_ROLE_WEIGHT[required];
 }
 
 export interface AuthorizedEvent {
@@ -59,13 +82,20 @@ export async function requireEventAccess(
   }
 
   if (options.allowMembers) {
-    const membership = await db.get<{ user_id: number }>(
-      'SELECT user_id FROM event_members WHERE event_id = $1 AND user_id = $2',
+    const membership = await db.get<{ user_id: number; role: string }>(
+      'SELECT user_id, role FROM event_members WHERE event_id = $1 AND user_id = $2',
       [eventId, req.user.id],
     );
 
     if (membership) {
-      return event;
+      if (!options.minEventRole) {
+        return event;
+      }
+
+      const normalized = normalizeEventRole(membership.role);
+      if (normalized && hasMinimumEventRole(normalized, options.minEventRole)) {
+        return event;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary\n- add deterministic Entra group-to-role mapping with precedence for SSO logins\n- harden refresh-token response to keep raw access token out of production responses\n- normalize event member roles to Owner/Co-Organizer/Helper/Guest with precedence-aware access checks\n- add RBAC audit logging for role and permission change operations\n- extend tests for Entra group mapping and refresh-token production behavior\n\n## Testing\n- attempted: 
> festival-event-planner@0.1.0 test
> vitest run entra-auth.test.ts refresh-token-cookie.test.ts


 RUN  v2.1.9 /home/smitramoliya2299/source/devel/eQuip/break-things-here (blocked locally: PostgreSQL test DB  missing)\n\nRefs #520