### PR TITLE
feat(ai): move AI rate-limit from in-process Map to DB-backed ai_rate_limits #664

### DIFF
--- a/backend/src/controllers/ai-controller.ts
+++ b/backend/src/controllers/ai-controller.ts
@@ -83,20 +83,35 @@ interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
 }
 
-// Per-user rate limit: 20 AI requests per hour stored in-process
-const userRateLimiter = new Map<number, { count: number; windowStart: number }>();
+// Per-user rate limit: 20 AI requests per rolling 1-hour window, persisted
+// in the ai_rate_limits table so the budget survives server restarts and is
+// enforced uniformly across multiple replicas. The UPSERT below is atomic —
+// it resets count to 1 when the existing window is older than 1 hour, or
+// increments otherwise, and returns the new count in the same round-trip.
+const AI_RATE_LIMIT_PER_HOUR = 20;
+const AI_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
-function checkAiRateLimit(userId: number): boolean {
-  const now = Date.now();
-  const ONE_HOUR = 60 * 60 * 1000;
-  const record = userRateLimiter.get(userId);
-  if (!record || (now - record.windowStart) > ONE_HOUR) {
-    userRateLimiter.set(userId, { count: 1, windowStart: now });
-    return true;
-  }
-  if (record.count >= 20) return false;
-  record.count++;
-  return true;
+async function checkAiRateLimit(userId: number): Promise<boolean> {
+  const db = getDatabase();
+  const row = await db.get<{ count: number }>(
+    `INSERT INTO ai_rate_limits (user_id, window_start, count, updated_at)
+     VALUES ($1, NOW(), 1, NOW())
+     ON CONFLICT (user_id) DO UPDATE
+       SET count = CASE
+                     WHEN (EXTRACT(EPOCH FROM (NOW() - ai_rate_limits.window_start)) * 1000) > $2
+                     THEN 1
+                     ELSE ai_rate_limits.count + 1
+                   END,
+           window_start = CASE
+                            WHEN (EXTRACT(EPOCH FROM (NOW() - ai_rate_limits.window_start)) * 1000) > $2
+                            THEN NOW()
+                            ELSE ai_rate_limits.window_start
+                          END,
+           updated_at = NOW()
+     RETURNING count`,
+    [userId, AI_RATE_LIMIT_WINDOW_MS],
+  );
+  return (row?.count ?? Number.POSITIVE_INFINITY) <= AI_RATE_LIMIT_PER_HOUR;
 }
 
 /** Sanitise user-supplied text before including in prompts to prevent prompt injection. */
@@ -120,7 +135,7 @@ export async function getSuggestion(req: AuthRequest, res: Response): Promise<Re
   }
 
   const userId = req.user?.id;
-  if (userId !== undefined && !checkAiRateLimit(userId)) {
+  if (userId !== undefined && !(await checkAiRateLimit(userId))) {
     return res.status(429).json({ error: 'AI rate limit exceeded. You can make 20 AI requests per hour.' });
   }
 

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -2619,4 +2619,16 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
   // Brought in from develop during merge of feature/664-wire-v9-schema-gaps.
   await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS event_time TEXT`);
   await db.exec(`ALTER TABLE event_templates ADD COLUMN IF NOT EXISTS default_event_time TEXT`);
+
+  // v9.3 — Persist AI rate-limit state so a single user's 20/hr budget survives
+  //         server restarts and is enforced across multiple replicas. Previously
+  //         lived in an in-process Map (backend/src/controllers/ai-controller.ts).
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS ai_rate_limits (
+      user_id      INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      window_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      count        INTEGER NOT NULL DEFAULT 0,
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
 }


### PR DESCRIPTION
## Summary
The per-user AI suggestion rate-limit (20/hr) lived in an in-process \`Map\` (\`backend/src/controllers/ai-controller.ts\`). Two real problems:

1. **Server restart wipes budgets** — users get a fresh 20/hr right after every deploy.
2. **Multi-replica = budget multiplied** — each process allows 20, so the effective ceiling = 20 × replicaCount.

## Fix
- **New v9.3 migration** in \`runMigrations()\`: \`ai_rate_limits(user_id PK, window_start, count, updated_at)\`. Idempotent (\`CREATE TABLE IF NOT EXISTS\`).
- **Atomic UPSERT** with \`ON CONFLICT (user_id) DO UPDATE … RETURNING count\` — resets the window when older than 1 hour, increments otherwise, returns the post-update count in a single round-trip. No TOCTOU race.

## What did NOT change
- The \`20/hour\` cap and the \`429\` response body are identical.
- No new env vars; no API surface change.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Full Vitest run in CI
- [ ] Manual: confirm a fresh deploy doesn't reset an active user's window (would need integration test against a live DB; deferred to CI on develop)

Closes #664 (C3 sub-item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)