### PR TITLE
feat(tasks): multi-assignee API on top of task_assignees (B1.2 of #523)

### DIFF
--- a/backend/__tests__/multi-assignee-tasks.test.ts
+++ b/backend/__tests__/multi-assignee-tasks.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createPostgresTestDatabase, type TestDatabase } from './helpers/postgres-test-db.js';
+
+// Test surface for B1.2 — the multi-assignee API on top of task_assignees.
+// We exercise list/create/update + the dedicated add/remove endpoints and
+// assert both the response shape (assignees array) and the underlying rows
+// in task_assignees (incl. the legacy assigned_user_id mirror).
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL DEFAULT 'x',
+  display_name TEXT NOT NULL DEFAULT '',
+  role_id INTEGER DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS events (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  date TEXT NOT NULL DEFAULT '',
+  location TEXT NOT NULL DEFAULT '',
+  created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  deleted_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS event_members (
+  event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT DEFAULT 'Member',
+  PRIMARY KEY (event_id, user_id)
+);
+CREATE TABLE IF NOT EXISTS tasks (
+  id SERIAL PRIMARY KEY,
+  event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  notes TEXT,
+  assignee_name TEXT,
+  assigned_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  due_date TEXT,
+  status TEXT DEFAULT 'Pending',
+  priority TEXT DEFAULT 'Medium',
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS task_assignees (
+  task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (task_id, user_id)
+);
+CREATE TABLE IF NOT EXISTS audit_log (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER, email TEXT, action TEXT NOT NULL, description TEXT,
+  ip_address TEXT, actor_id INTEGER, target_type TEXT, target_id TEXT,
+  context JSONB, severity TEXT DEFAULT 'INFO',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`;
+
+let testDb: TestDatabase | undefined;
+let alice: number;
+let bob: number;
+let carol: number;
+let eventId: number;
+
+beforeEach(async () => {
+  testDb = await createPostgresTestDatabase(SCHEMA_SQL);
+
+  // Wire the test DB into the controller via the database module's adapter.
+  vi.doMock('../src/db/database.js', () => ({
+    getDatabase: () => testDb,
+    // event-access asserts membership against this — adapter satisfies its shape.
+  }));
+  // event-access.requireEventAccess does its own DB lookups; for these unit
+  // tests we mock it to always grant access.
+  vi.doMock('../src/utils/event-access.js', () => ({
+    requireEventAccess: vi.fn().mockResolvedValue({ id: 1 }),
+  }));
+  vi.doMock('./activity-feed-controller.js', () => ({
+    logActivity: vi.fn(),
+  }));
+
+  const usersRows = await Promise.all([
+    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('alice@example.com', 'Alice') RETURNING id`),
+    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('bob@example.com', 'Bob') RETURNING id`),
+    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('carol@example.com', 'Carol') RETURNING id`),
+  ]);
+  alice = usersRows[0].lastID!;
+  bob = usersRows[1].lastID!;
+  carol = usersRows[2].lastID!;
+  const ev = await testDb!.run(`INSERT INTO events (title, created_by) VALUES ('Ev', $1) RETURNING id`, [alice]);
+  eventId = ev.lastID!;
+  for (const u of [alice, bob, carol]) {
+    await testDb!.run('INSERT INTO event_members (event_id, user_id, role) VALUES ($1,$2,$3)', [eventId, u, 'Member']);
+  }
+});
+
+afterEach(async () => {
+  await testDb?.close();
+  vi.resetModules();
+});
+
+function makeRes(): Response & { statusCode: number; body: unknown } {
+  const r: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  r.status = ((code: number) => {
+    r.statusCode = code;
+    return r as Response;
+  }) as Response['status'];
+  r.json = ((payload: unknown) => {
+    r.body = payload;
+    return r as Response;
+  }) as Response['json'];
+  return r as Response & { statusCode: number; body: unknown };
+}
+
+function makeReq(params: Record<string, string>, body: unknown, userId = alice): Request {
+  return {
+    params,
+    body,
+    user: { id: userId, email: 'alice@example.com', role_id: 1 },
+  } as unknown as Request;
+}
+
+describe('multi-assignee tasks API (B1.2)', () => {
+  it('createTask with assignee_user_ids writes rows in task_assignees and mirrors primary', async () => {
+    const { createTask } = await import('../src/controllers/tasks-controller.js');
+    const res = makeRes();
+    const req = makeReq(
+      { eventId: String(eventId) },
+      { title: 'plan venue', assignee_user_ids: [bob, carol] },
+    );
+    await createTask(req as unknown as Parameters<typeof createTask>[0], res);
+    expect(res.statusCode).toBe(201);
+    const created = (res.body as { task: { id: number; assigned_user_id: number; assignees: unknown[] } }).task;
+    expect(created.assigned_user_id).toBe(bob); // primary mirrored
+    expect(created.assignees).toHaveLength(2);
+
+    const rows = await testDb!.all<{ user_id: number; is_primary: boolean }>(
+      'SELECT user_id, is_primary FROM task_assignees WHERE task_id = $1 ORDER BY is_primary DESC, assigned_at ASC',
+      [created.id],
+    );
+    expect(rows.map((r) => r.user_id)).toEqual([bob, carol]);
+    expect(rows[0].is_primary).toBe(true);
+    expect(rows[1].is_primary).toBe(false);
+  });
+
+  it('createTask with legacy assigned_user_id still works and backfills task_assignees', async () => {
+    const { createTask } = await import('../src/controllers/tasks-controller.js');
+    const res = makeRes();
+    await createTask(
+      makeReq({ eventId: String(eventId) }, { title: 't', assigned_user_id: carol }) as unknown as Parameters<typeof createTask>[0],
+      res,
+    );
+    expect(res.statusCode).toBe(201);
+    const created = (res.body as { task: { id: number; assignees: unknown[] } }).task;
+    expect(created.assignees).toHaveLength(1);
+    const rows = await testDb!.all<{ user_id: number; is_primary: boolean }>(
+      'SELECT user_id, is_primary FROM task_assignees WHERE task_id = $1',
+      [created.id],
+    );
+    expect(rows).toEqual([{ user_id: carol, is_primary: true }]);
+  });
+
+  it('updateTask with assignee_user_ids replaces the entire assignee set', async () => {
+    const { createTask, updateTask } = await import('../src/controllers/tasks-controller.js');
+    const createRes = makeRes();
+    await createTask(
+      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [bob] }) as unknown as Parameters<typeof createTask>[0],
+      createRes,
+    );
+    const taskId = ((createRes.body as { task: { id: number } }).task).id;
+
+    const updateRes = makeRes();
+    await updateTask(
+      makeReq({ id: String(taskId), eventId: String(eventId) }, { assignee_user_ids: [carol, alice] }),
+      updateRes,
+    );
+    expect(updateRes.statusCode).toBe(200);
+    const rows = await testDb!.all<{ user_id: number; is_primary: boolean }>(
+      'SELECT user_id, is_primary FROM task_assignees WHERE task_id = $1 ORDER BY is_primary DESC, assigned_at ASC',
+      [taskId],
+    );
+    expect(rows.map((r) => r.user_id)).toEqual([carol, alice]); // bob removed
+    expect(rows[0].is_primary).toBe(true);
+    const mirror = await testDb!.get<{ assigned_user_id: number }>(
+      'SELECT assigned_user_id FROM tasks WHERE id = $1',
+      [taskId],
+    );
+    expect(mirror?.assigned_user_id).toBe(carol);
+  });
+
+  it('rejects assignee_user_ids containing a non-event-member', async () => {
+    const { createTask } = await import('../src/controllers/tasks-controller.js');
+    // Create a 4th user who is NOT a member of the event.
+    const stranger = (await testDb!.run(
+      `INSERT INTO users (email, display_name) VALUES ('mallory@example.com', 'Mallory') RETURNING id`,
+    )).lastID!;
+    const res = makeRes();
+    await createTask(
+      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [bob, stranger] }) as unknown as Parameters<typeof createTask>[0],
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/not a member/i);
+    // No rows written.
+    const rows = await testDb!.all('SELECT * FROM task_assignees', []);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('addAssignee + removeAssignee endpoints adjust the M:N set and promote next primary on primary removal', async () => {
+    const { createTask, addAssignee, removeAssignee } = await import('../src/controllers/tasks-controller.js');
+    const createRes = makeRes();
+    await createTask(
+      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [alice] }) as unknown as Parameters<typeof createTask>[0],
+      createRes,
+    );
+    const taskId = ((createRes.body as { task: { id: number } }).task).id;
+
+    // Add bob (secondary).
+    const addRes = makeRes();
+    await addAssignee(
+      makeReq({ eventId: String(eventId), taskId: String(taskId) }, { user_id: bob }),
+      addRes,
+    );
+    expect(addRes.statusCode).toBe(201);
+
+    // Remove alice (the primary) — bob should become the new primary.
+    const delRes = makeRes();
+    await removeAssignee(
+      makeReq({ eventId: String(eventId), taskId: String(taskId), userId: String(alice) }, {}),
+      delRes,
+    );
+    expect(delRes.statusCode).toBe(200);
+    const rows = await testDb!.all<{ user_id: number; is_primary: boolean }>(
+      'SELECT user_id, is_primary FROM task_assignees WHERE task_id = $1',
+      [taskId],
+    );
+    expect(rows).toEqual([{ user_id: bob, is_primary: true }]);
+    const mirror = await testDb!.get<{ assigned_user_id: number }>(
+      'SELECT assigned_user_id FROM tasks WHERE id = $1',
+      [taskId],
+    );
+    expect(mirror?.assigned_user_id).toBe(bob);
+  });
+});

--- a/backend/src/controllers/tasks-controller.ts
+++ b/backend/src/controllers/tasks-controller.ts
@@ -20,6 +20,119 @@ async function getTaskTeamMemberIds(db: ReturnType<typeof getDatabase>, eventId:
   return new Set(rows.map((row) => Number(row.user_id)));
 }
 
+// ─── task_assignees (M:N) helpers — B1.2 ─────────────────────────────────────
+
+export interface AssigneeRow {
+  user_id: number;
+  display_name: string | null;
+  email: string | null;
+  is_primary: boolean;
+}
+
+/**
+ * Resolve and validate the requested assignee user_ids for an event-scoped
+ * task. Returns the normalized list in input order. The first id is the
+ * primary; duplicates are removed; non-members raise an error.
+ *
+ * Returning `null` means a caller-supplied value was malformed/empty and
+ * the request should respond 400 with the embedded message.
+ */
+async function normaliseAssigneeIds(
+  db: ReturnType<typeof getDatabase>,
+  eventId: string,
+  raw: unknown,
+): Promise<{ ok: true; ids: number[] } | { ok: false; error: string }> {
+  if (raw === undefined || raw === null) return { ok: true, ids: [] };
+  if (!Array.isArray(raw)) {
+    return { ok: false, error: 'assignee_user_ids must be an array of integers.' };
+  }
+  const seen = new Set<number>();
+  const ordered: number[] = [];
+  for (const value of raw) {
+    const n = Number(value);
+    if (!Number.isInteger(n)) {
+      return { ok: false, error: 'assignee_user_ids entries must be integers.' };
+    }
+    if (seen.has(n)) continue;
+    seen.add(n);
+    ordered.push(n);
+  }
+  if (ordered.length === 0) return { ok: true, ids: [] };
+  const teamMembers = await getTaskTeamMemberIds(db, eventId);
+  const stranger = ordered.find((id) => !teamMembers.has(id));
+  if (stranger !== undefined) {
+    return { ok: false, error: `User ${stranger} is not a member of this event.` };
+  }
+  return { ok: true, ids: ordered };
+}
+
+/**
+ * Replace the assignee set for a task. The first id in the array becomes
+ * is_primary=true and is mirrored to the legacy `tasks.assigned_user_id`
+ * column so existing readers and the dashboard "owner" view keep working
+ * through the migration window.
+ *
+ * Called from createTask + updateTask + the new explicit add/remove
+ * endpoints. Idempotent: re-setting the same list is a no-op.
+ */
+async function replaceTaskAssignees(
+  db: ReturnType<typeof getDatabase>,
+  taskId: number,
+  userIds: number[],
+): Promise<void> {
+  // Wipe and rewrite — this is a small set per task (typically <5 rows) so
+  // doing it transactionally via the adapter is simpler than diffing.
+  await db.run('DELETE FROM task_assignees WHERE task_id = ?', [taskId]);
+  for (let i = 0; i < userIds.length; i++) {
+    await db.run(
+      `INSERT INTO task_assignees (task_id, user_id, is_primary)
+       VALUES (?, ?, ?)
+       ON CONFLICT (task_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary`,
+      [taskId, userIds[i], i === 0],
+    );
+  }
+  // Mirror primary to legacy column (or null when assignee set is empty).
+  await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [
+    userIds[0] ?? null,
+    taskId,
+  ]);
+}
+
+/** Single round-trip load of assignees for a set of task ids. Avoids N+1 in listTasks. */
+async function loadAssigneesForTasks(
+  db: ReturnType<typeof getDatabase>,
+  taskIds: number[],
+): Promise<Map<number, AssigneeRow[]>> {
+  const map = new Map<number, AssigneeRow[]>();
+  if (taskIds.length === 0) return map;
+  const placeholders = taskIds.map(() => '?').join(',');
+  const rows = await db.all<{
+    task_id: number;
+    user_id: number;
+    display_name: string | null;
+    email: string | null;
+    is_primary: boolean;
+  }>(
+    `SELECT ta.task_id, ta.user_id, ta.is_primary, u.display_name, u.email
+       FROM task_assignees ta
+       LEFT JOIN users u ON u.id = ta.user_id AND u.deleted_at IS NULL
+      WHERE ta.task_id IN (${placeholders})
+      ORDER BY ta.is_primary DESC, ta.assigned_at ASC`,
+    taskIds,
+  );
+  for (const row of rows) {
+    const bucket = map.get(Number(row.task_id)) ?? [];
+    bucket.push({
+      user_id: Number(row.user_id),
+      display_name: row.display_name,
+      email: row.email,
+      is_primary: Boolean(row.is_primary),
+    });
+    map.set(Number(row.task_id), bucket);
+  }
+  return map;
+}
+
 /** GET /api/events/:eventId/tasks */
 export async function listTasks(req: Request, res: Response): Promise<Response> {
   const authReq = req as AuthRequest;
@@ -27,7 +140,7 @@ export async function listTasks(req: Request, res: Response): Promise<Response> 
   const { eventId } = req.params;
   const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
-  const rows = await db.all(
+  const rows = await db.all<{ id: number } & Record<string, unknown>>(
     `SELECT t.*, COALESCE(u.display_name, t.assignee_name) AS assignee_name
      FROM tasks t
      LEFT JOIN users u ON t.assigned_user_id = u.id
@@ -35,21 +148,30 @@ export async function listTasks(req: Request, res: Response): Promise<Response> 
      ORDER BY t.due_date ASC, t.priority ASC`,
     [eventId],
   );
-  return res.json({ tasks: rows });
+  const ids = rows.map((r) => Number(r.id));
+  const assignees = await loadAssigneesForTasks(db, ids);
+  const tasks = rows.map((row) => ({
+    ...row,
+    assignees: assignees.get(Number(row.id)) ?? [],
+  }));
+  return res.json({ tasks });
 }
 
 /** POST /api/events/:eventId/tasks */
 export async function createTask(req: AuthRequest, res: Response): Promise<Response> {
   const { eventId } = req.params;
-  const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = req.body as {
+  const body = req.body as {
     title?: string;
     notes?: string;
     assignee_name?: string;
     assigned_user_id?: number | string;
+    // B1.2: explicit M:N list; first id becomes primary.
+    assignee_user_ids?: unknown;
     due_date?: string;
     status?: string;
     priority?: string;
   };
+  const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = body;
 
   if (!title?.trim()) return res.status(400).json({ error: 'Task title is required.' });
   if (status && !ALLOWED_STATUSES.has(status)) return res.status(400).json({ error: 'Invalid task status.' });
@@ -60,16 +182,33 @@ export async function createTask(req: AuthRequest, res: Response): Promise<Respo
   const event = await requireEventAccess(req, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
 
-  let assignedUserId: number | null = null;
-  let derivedAssigneeName = assignee_name?.trim() || null;
-  if (assigned_user_id !== undefined && assigned_user_id !== null && assigned_user_id !== '') {
-    assignedUserId = Number(assigned_user_id);
-    if (!Number.isInteger(assignedUserId)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+  // Resolve assignee set. Precedence:
+  //   1. assignee_user_ids (new M:N path) when supplied.
+  //   2. assigned_user_id (legacy single) when supplied.
+  //   3. neither — task is unassigned.
+  let assigneeIds: number[] = [];
+  if (body.assignee_user_ids !== undefined) {
+    const parsed = await normaliseAssigneeIds(db, eventId, body.assignee_user_ids);
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+    assigneeIds = parsed.ids;
+  } else if (assigned_user_id !== undefined && assigned_user_id !== null && assigned_user_id !== '') {
+    const n = Number(assigned_user_id);
+    if (!Number.isInteger(n)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
     const teamMembers = await getTaskTeamMemberIds(db, eventId);
-    if (!teamMembers.has(assignedUserId)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
-    const assignee = await db.get<{ display_name: string }>('SELECT display_name FROM users WHERE id = $1 AND deleted_at IS NULL', [assignedUserId]);
-    if (!assignee) return res.status(404).json({ error: 'Assigned user not found.' });
-    derivedAssigneeName = assignee.display_name;
+    if (!teamMembers.has(n)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+    assigneeIds = [n];
+  }
+
+  // Derive the display_name shown in legacy list responses from the primary
+  // assignee, if any; fall back to whatever the client posted.
+  let derivedAssigneeName = assignee_name?.trim() || null;
+  if (assigneeIds.length > 0) {
+    const primary = await db.get<{ display_name: string }>(
+      'SELECT display_name FROM users WHERE id = $1 AND deleted_at IS NULL',
+      [assigneeIds[0]],
+    );
+    if (!primary) return res.status(404).json({ error: 'Primary assignee user not found.' });
+    derivedAssigneeName = primary.display_name;
   }
 
   const result = await db.run(
@@ -81,7 +220,7 @@ export async function createTask(req: AuthRequest, res: Response): Promise<Respo
       title.trim(),
       notes?.trim() || null,
       derivedAssigneeName,
-      assignedUserId,
+      assigneeIds[0] ?? null,
       due_date || null,
       normalizeTaskStatus(status),
       priority || 'Medium',
@@ -89,7 +228,21 @@ export async function createTask(req: AuthRequest, res: Response): Promise<Respo
     ],
   );
 
-  const task = await db.get('SELECT * FROM tasks WHERE id = $1', [result.lastID]);
+  if (result.lastID !== undefined && assigneeIds.length > 0) {
+    await replaceTaskAssignees(db, result.lastID, assigneeIds);
+  }
+
+  const taskRow = await db.get<{ id: number } & Record<string, unknown>>(
+    'SELECT * FROM tasks WHERE id = $1',
+    [result.lastID],
+  );
+  const assigneesMap = await loadAssigneesForTasks(
+    db,
+    taskRow?.id !== undefined ? [Number(taskRow.id)] : [],
+  );
+  const task = taskRow
+    ? { ...taskRow, assignees: assigneesMap.get(Number(taskRow.id)) ?? [] }
+    : null;
 
   await logActivity(
     eventId,
@@ -117,22 +270,54 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
   const task = await db.get('SELECT * FROM tasks WHERE id = $1 AND event_id = $2', [id, eventId]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
-  const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = req.body as Record<string, string>;
+  const body = req.body as Record<string, unknown>;
+  const title = body.title as string | undefined;
+  const notes = body.notes as string | undefined;
+  const assignee_name = body.assignee_name as string | undefined;
+  const assigned_user_id = body.assigned_user_id as string | number | undefined;
+  const due_date = body.due_date as string | undefined;
+  const status = body.status as string | undefined;
+  const priority = body.priority as string | undefined;
   const fields: string[] = [];
   const params: (string | number | null)[] = [];
 
-  let derivedAssigneeName = assignee_name;
-  if (assigned_user_id !== undefined) {
-    const assignedUserId = Number(assigned_user_id);
-    if (!Number.isInteger(assignedUserId)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
-    const teamMembers = await getTaskTeamMemberIds(db, String(task.event_id));
-    if (!teamMembers.has(assignedUserId)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
-    const assignee = await db.get<{ display_name: string }>('SELECT display_name FROM users WHERE id = $1 AND deleted_at IS NULL', [assignedUserId]);
-    if (!assignee) return res.status(404).json({ error: 'Assigned user not found.' });
+  // B1.2: if assignee_user_ids is supplied it replaces the whole assignee
+  // set via task_assignees. The legacy assigned_user_id field is still
+  // accepted but is interpreted as a single-element list.
+  let newAssigneeIds: number[] | null = null;
+  if (body.assignee_user_ids !== undefined) {
+    const parsed = await normaliseAssigneeIds(db, eventId, body.assignee_user_ids);
+    if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+    newAssigneeIds = parsed.ids;
+  } else if (assigned_user_id !== undefined) {
+    if (assigned_user_id === null || assigned_user_id === '') {
+      newAssigneeIds = [];
+    } else {
+      const n = Number(assigned_user_id);
+      if (!Number.isInteger(n)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+      const teamMembers = await getTaskTeamMemberIds(db, String(task.event_id));
+      if (!teamMembers.has(n)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+      newAssigneeIds = [n];
+    }
+  }
+
+  // Mirror the primary into the legacy column in the same UPDATE so
+  // legacy readers (dashboard owner pill, etc.) stay consistent.
+  if (newAssigneeIds !== null) {
     fields.push('assigned_user_id = ?');
-    params.push(assignedUserId);
-    fields.push('assignee_name = ?');
-    params.push(assignee.display_name);
+    params.push(newAssigneeIds[0] ?? null);
+    if (newAssigneeIds.length > 0) {
+      const primary = await db.get<{ display_name: string }>(
+        'SELECT display_name FROM users WHERE id = $1 AND deleted_at IS NULL',
+        [newAssigneeIds[0]],
+      );
+      if (!primary) return res.status(404).json({ error: 'Primary assignee user not found.' });
+      fields.push('assignee_name = ?');
+      params.push(primary.display_name);
+    } else {
+      fields.push('assignee_name = ?');
+      params.push(null);
+    }
   }
 
   if (title !== undefined) { fields.push('title = ?'); params.push(title.trim()); }
@@ -148,30 +333,49 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
     fields.push('priority = ?');
     params.push(priority);
   }
-  if (assignee_name !== undefined && assigned_user_id === undefined) { fields.push('assignee_name = ?'); params.push(assignee_name.trim() || null); }
+  if (assignee_name !== undefined && assigned_user_id === undefined && body.assignee_user_ids === undefined) {
+    fields.push('assignee_name = ?');
+    params.push(assignee_name.trim() || null);
+  }
 
   if (fields.length === 0) return res.status(400).json({ error: 'No fields to update.' });
 
   fields.push('updated_at = CURRENT_TIMESTAMP');
   params.push(id);
 
-  await db.run(`UPDATE tasks SET ${fields.join(', ')} WHERE id = $1`, params);
-  const updated = await db.get(
+  // Use `?` for the WHERE clause too so convertPlaceholders renumbers every
+  // bind consistently — mixing `$1` here with `?` in the fields collapses
+  // the WHERE param onto the first SET param.
+  await db.run(`UPDATE tasks SET ${fields.join(', ')} WHERE id = ?`, params);
+
+  // Sync the M:N table after the scalar update so the response below sees
+  // both sources consistent. Skipped when no assignee change was requested.
+  if (newAssigneeIds !== null) {
+    await replaceTaskAssignees(db, Number(id), newAssigneeIds);
+  }
+
+  const updatedRow = await db.get<{ id: number } & Record<string, unknown>>(
     `SELECT t.*, COALESCE(u.display_name, t.assignee_name) AS assignee_name
      FROM tasks t
      LEFT JOIN users u ON t.assigned_user_id = u.id
      WHERE t.id = $1`,
     [id],
   );
+  const assigneesMap = await loadAssigneesForTasks(
+    db,
+    updatedRow?.id !== undefined ? [Number(updatedRow.id)] : [],
+  );
+  const updated = updatedRow
+    ? { ...updatedRow, assignees: assigneesMap.get(Number(updatedRow.id)) ?? [] }
+    : null;
 
   const newTaskStatus = normalizeTaskStatus(status);
   if (newTaskStatus === 'Complete' && task.status !== 'Complete') {
-    const authReq = req as AuthRequest;
     await logActivity(
       String(task.event_id),
       authReq.user?.id ?? null,
       'task_completed',
-      `Task completed: ${(updated as Record<string, unknown>)['title'] as string ?? 'Unknown'}`,
+      `Task completed: ${(updated as Record<string, unknown> | null)?.['title'] as string ?? 'Unknown'}`,
       `/events/${task.event_id as string}`,
     );
   }
@@ -195,6 +399,116 @@ export async function deleteTask(req: Request, res: Response): Promise<Response>
   await db.run('DELETE FROM tasks WHERE id = $1', [id]);
   await logMutation(db, authReq, AUDIT_ACTIONS.TASK_DELETE, 'task', id, { eventId });
   return res.json({ message: 'Task deleted.' });
+}
+
+// ── Assignees (M:N) — granular add/remove — B1.2 ────────────────────────────
+
+/** GET /api/events/:eventId/tasks/:taskId/assignees */
+export async function listAssignees(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { eventId, taskId } = req.params;
+  const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
+  if (!event) return res as Response;
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  if (!task) return res.status(404).json({ error: 'Task not found.' });
+  const map = await loadAssigneesForTasks(db, [Number(taskId)]);
+  return res.json({ assignees: map.get(Number(taskId)) ?? [] });
+}
+
+/** POST /api/events/:eventId/tasks/:taskId/assignees  body: { user_id, is_primary? } */
+export async function addAssignee(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { eventId, taskId } = req.params;
+  const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
+  if (!event) return res as Response;
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  if (!task) return res.status(404).json({ error: 'Task not found.' });
+
+  const body = req.body as { user_id?: number | string; is_primary?: boolean };
+  const userId = Number(body.user_id);
+  if (!Number.isInteger(userId)) {
+    return res.status(400).json({ error: 'user_id must be a valid integer.' });
+  }
+  const teamMembers = await getTaskTeamMemberIds(db, eventId);
+  if (!teamMembers.has(userId)) {
+    return res.status(400).json({ error: 'User is not a member of this event.' });
+  }
+
+  // Promote to primary if requested; otherwise add as a secondary assignee.
+  if (body.is_primary) {
+    // Demote any existing primary first so the constraint stays clean.
+    await db.run('UPDATE task_assignees SET is_primary = FALSE WHERE task_id = ?', [taskId]);
+    await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [userId, taskId]);
+  }
+  await db.run(
+    `INSERT INTO task_assignees (task_id, user_id, is_primary)
+     VALUES (?, ?, ?)
+     ON CONFLICT (task_id, user_id) DO UPDATE SET is_primary = EXCLUDED.is_primary`,
+    [taskId, userId, Boolean(body.is_primary)],
+  );
+
+  await logMutation(db, authReq, AUDIT_ACTIONS.TASK_UPDATE, 'task', taskId, {
+    eventId,
+    op: 'add_assignee',
+    user_id: userId,
+    is_primary: Boolean(body.is_primary),
+  });
+
+  const map = await loadAssigneesForTasks(db, [Number(taskId)]);
+  return res.status(201).json({ assignees: map.get(Number(taskId)) ?? [] });
+}
+
+/** DELETE /api/events/:eventId/tasks/:taskId/assignees/:userId */
+export async function removeAssignee(req: Request, res: Response): Promise<Response> {
+  const authReq = req as AuthRequest;
+  const db = getDatabase();
+  const { eventId, taskId, userId } = req.params;
+  const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
+  if (!event) return res as Response;
+  const task = await db.get<{ id: number; assigned_user_id: number | null }>(
+    'SELECT id, assigned_user_id FROM tasks WHERE id = $1 AND event_id = $2',
+    [taskId, eventId],
+  );
+  if (!task) return res.status(404).json({ error: 'Task not found.' });
+
+  const removed = await db.run(
+    'DELETE FROM task_assignees WHERE task_id = ? AND user_id = ?',
+    [taskId, userId],
+  );
+  if (removed.changes === 0) {
+    return res.status(404).json({ error: 'Assignee not found on this task.' });
+  }
+
+  // If the removed user was the legacy primary, promote whoever's left
+  // (earliest assigned_at) or clear the legacy column.
+  if (Number(task.assigned_user_id) === Number(userId)) {
+    const nextPrimary = await db.get<{ user_id: number }>(
+      `SELECT user_id FROM task_assignees
+        WHERE task_id = ?
+        ORDER BY assigned_at ASC LIMIT 1`,
+      [taskId],
+    );
+    if (nextPrimary) {
+      await db.run('UPDATE task_assignees SET is_primary = (user_id = ?) WHERE task_id = ?', [
+        nextPrimary.user_id,
+        taskId,
+      ]);
+      await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [nextPrimary.user_id, taskId]);
+    } else {
+      await db.run('UPDATE tasks SET assigned_user_id = NULL, assignee_name = NULL WHERE id = ?', [taskId]);
+    }
+  }
+
+  await logMutation(db, authReq, AUDIT_ACTIONS.TASK_UPDATE, 'task', taskId, {
+    eventId,
+    op: 'remove_assignee',
+    user_id: Number(userId),
+  });
+
+  const map = await loadAssigneesForTasks(db, [Number(taskId)]);
+  return res.json({ assignees: map.get(Number(taskId)) ?? [] });
 }
 
 // ── Comments ─────────────────────────────────────────────────────────────────

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -480,6 +480,10 @@ router.post('/events/:eventId/tasks', authenticateToken, tasksController.createT
 router.put('/events/:eventId/tasks/:id', authenticateToken, tasksController.updateTask);
 router.patch('/events/:eventId/tasks/:id', authenticateToken, tasksController.updateTask);
 router.delete('/events/:eventId/tasks/:id', authenticateToken, tasksController.deleteTask);
+// Multi-assignee task API (#523 B1.2)
+router.get('/events/:eventId/tasks/:taskId/assignees', authenticateToken, tasksController.listAssignees);
+router.post('/events/:eventId/tasks/:taskId/assignees', authenticateToken, tasksController.addAssignee);
+router.delete('/events/:eventId/tasks/:taskId/assignees/:userId', authenticateToken, tasksController.removeAssignee);
 router.get('/events/:eventId/tasks/:taskId/comments', authenticateToken, tasksController.listComments);
 router.post('/events/:eventId/tasks/:taskId/comments', authenticateToken, tasksController.addComment);
 router.post('/events/:eventId/tasks/:taskId/subtasks', authenticateToken, tasksController.addSubtask);


### PR DESCRIPTION
## Summary
**B1.2** from the story #523 7-PR breakdown. Reads and writes go through the M:N \`task_assignees\` table (introduced in B1.1 / PR #721). The legacy \`tasks.assigned_user_id\` column is kept in lockstep so existing readers (dashboard "owner" pill, list views) still work through the migration window.

## API changes — \`tasks-controller.ts\` (event-scoped)

### Response shape — list & detail
Each task now carries an \`assignees\` array:
\`\`\`json
{
  "id": 12,
  "title": "Plan venue",
  "assigned_user_id": 5,            // legacy mirror (primary)
  "assignee_name": "Alice",         // legacy mirror
  "assignees": [
    { "user_id": 5, "display_name": "Alice", "email": "alice@…", "is_primary": true },
    { "user_id": 7, "display_name": "Bob",   "email": "bob@…",   "is_primary": false }
  ]
}
\`\`\`
The list endpoint loads all assignees in a single bulk JOIN (no N+1).

### Mutations
- **createTask** accepts \`assignee_user_ids: number[]\` (new, preferred — first id is primary) **OR** \`assigned_user_id\` (legacy, single). Mutually exclusive; new form wins.
- **updateTask** accepts the same two shapes. Supplying \`assignee_user_ids\` **replaces** the whole assignee set. Clearing legacy \`assigned_user_id\` to \`""\` or \`null\` clears all assignees. No-op when neither field is sent.

### New endpoints
\`\`\`
GET    /api/events/:eventId/tasks/:taskId/assignees
POST   /api/events/:eventId/tasks/:taskId/assignees   body: { user_id, is_primary? }
DELETE /api/events/:eventId/tasks/:taskId/assignees/:userId
\`\`\`
Removing the primary auto-promotes the earliest-assigned remaining user and mirrors them to the legacy column.

## Validation
- All \`user_id\`s must be members of the event (\`event_members\` lookup).
- Duplicates in input are de-duped, order preserved.
- Non-array or non-integer entries → 400 with a specific message.

## Side fix — pre-existing placeholder bug
\`updateTask\`'s dynamic UPDATE built \`… WHERE id = $1\` mixed with \`?\` placeholders in the SET list. \`convertPlaceholders\` renumbered the \`?\`s to \`$1..$N\` and collapsed the WHERE bind onto the first SET param — a latent bug whenever updateTask had ≥2 SET fields (including the new M:N path). Switched the WHERE to \`?\` so every placeholder is renumbered uniformly.

## Test plan
- [x] 5 new integration tests against real Postgres in \`__tests__/multi-assignee-tasks.test.ts\` — all green
- [x] \`tsc --noEmit\` clean
- [x] 17/17 adjacent suites pass (log-mutation, mailer, expense-workflow, budget-operations)
- [ ] Full CI on PR

## What this PR does NOT do (separate PRs from the breakdown)
- B1.3: background escalation worker (uses \`task_escalation_rules\`)
- B1.4: apply-timeline-template flow
- B1.5: SSE collab stream
- B1.6: rollback via \`entity_change_history\`
- B1.7: E2E concurrent-edit tests

Refs #523 (B1.2 of 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)