### PR TITLE
feat(guests): add XLSX support to guest import wizard

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "pg": "^8.20.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
+        "xlsx": "^0.18.5",
         "xss": "^1.0.15"
       },
       "devDependencies": {
@@ -1730,6 +1731,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1993,6 +2003,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2035,6 +2058,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -2178,6 +2210,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2938,6 +2982,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -4539,6 +4592,18 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5754,6 +5819,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5769,6 +5852,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/xss": {
       "version": "1.0.15",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "pg": "^8.20.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "xlsx": "^0.18.5",
     "xss": "^1.0.15"
   },
   "devDependencies": {

--- a/backend/src/controllers/rsvps-controller.ts
+++ b/backend/src/controllers/rsvps-controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import * as XLSX from 'xlsx';
 import { getDatabase } from '../db/database.js';
 import { createRsvpNotification } from './notifications-controller.js';
 import { logActivity } from './activity-feed-controller.js';
@@ -838,65 +839,104 @@ export async function checkInGuest(req: Request, res: Response): Promise<Respons
   return res.json({ rsvp: updated });
 }
 
-/** POST /api/events/:eventId/rsvps/import — CSV file upload via multer */
+/** POST /api/events/:eventId/rsvps/import — CSV or XLSX file upload via multer */
 export async function importCsv(req: Request, res: Response): Promise<Response> {
   const authReq = req as AuthRequest;
   if (!authReq.user) return res.status(401).json({ error: 'Authentication required.' });
 
   const { eventId } = req.params;
   const file = (req as Request & { file?: Express.Multer.File }).file;
-  if (!file) return res.status(400).json({ error: 'No CSV file uploaded.' });
+  if (!file) return res.status(400).json({ error: 'No file uploaded.' });
 
   const db = getDatabase();
   const event = await requireEventAccess(authReq, res, eventId, { ownerOnly: true });
   if (!event) return res as Response;
 
-  const MAX_CSV_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
+  const MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MB
   const MAX_CSV_LINE_CHARS = 10_000;
-  const MAX_CSV_ROWS = 10_000;
+  const MAX_ROWS = 10_000;
 
-  if (file.buffer.length > MAX_CSV_FILE_BYTES) {
-    return res.status(400).json({ error: 'CSV file exceeds maximum allowed size of 5 MB.' });
+  if (file.buffer.length > MAX_FILE_BYTES) {
+    return res.status(400).json({ error: 'File exceeds maximum allowed size of 5 MB.' });
   }
 
-  const content = file.buffer.toString('utf8');
-  const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0);
-  if (lines.length < 2) return res.status(400).json({ error: 'CSV file has no data rows.' });
-  if (lines.length > MAX_CSV_ROWS + 1) {
-    return res
-      .status(400)
-      .json({ error: `CSV file exceeds maximum of ${MAX_CSV_ROWS} data rows.` });
-  }
+  // ── Detect file type and normalise to string[][] ────────────────────────
+  const lowerName = (file.originalname ?? '').toLowerCase();
+  const isExcel =
+    lowerName.endsWith('.xlsx') ||
+    lowerName.endsWith('.xls') ||
+    file.mimetype === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    file.mimetype === 'application/vnd.ms-excel';
 
-  // Parse simple CSV (supports quoted fields)
-  function parseCsvLine(line: string): string[] {
-    const result: string[] = [];
-    let current = '';
-    let inQuotes = false;
-    const safeLength = Math.min(line.length, MAX_CSV_LINE_CHARS);
-    for (let i = 0; i < safeLength; i++) {
-      const ch = line[i];
-      if (ch === '"') {
-        if (inQuotes && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = !inQuotes;
-        }
-      } else if (ch === ',' && !inQuotes) {
-        result.push(current.trim());
-        current = '';
-      } else {
-        current += ch;
+  let rawHeaders: string[] = [];
+  let dataLines2d: string[][] = [];
+
+  if (isExcel) {
+    try {
+      const workbook = XLSX.read(file.buffer, { type: 'buffer' });
+      const sheetName = workbook.SheetNames[0];
+      if (!sheetName) return res.status(400).json({ error: 'Excel file has no sheets.' });
+      const sheet = workbook.Sheets[sheetName];
+      const allRows = XLSX.utils.sheet_to_json<string[]>(sheet, {
+        header: 1,
+        defval: '',
+        range: 0,
+      }) as string[][];
+      const nonEmpty = allRows.filter((r) => r.some((c) => String(c ?? '').trim() !== ''));
+      if (nonEmpty.length < 2)
+        return res.status(400).json({ error: 'Excel file has no data rows.' });
+      if (nonEmpty.length > MAX_ROWS + 1) {
+        return res
+          .status(400)
+          .json({ error: `Excel file exceeds maximum of ${MAX_ROWS} data rows.` });
       }
+      rawHeaders = nonEmpty[0].map((h) => String(h ?? ''));
+      dataLines2d = nonEmpty.slice(1).map((r) => r.map((c) => String(c ?? '')));
+    } catch {
+      return res
+        .status(400)
+        .json({ error: 'Failed to parse Excel file. Please check the format.' });
     }
-    result.push(current.trim());
-    return result;
-  }
+  } else {
+    // ── CSV path ──────────────────────────────────────────────────────────
+    const content = file.buffer.toString('utf8');
+    const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0);
+    if (lines.length < 2) return res.status(400).json({ error: 'CSV file has no data rows.' });
+    if (lines.length > MAX_ROWS + 1) {
+      return res.status(400).json({ error: `CSV file exceeds maximum of ${MAX_ROWS} data rows.` });
+    }
 
-  const rawHeaders = parseCsvLine(lines[0]);
+    // Parse simple CSV (supports quoted fields)
+    function parseCsvLine(line: string): string[] {
+      const result: string[] = [];
+      let current = '';
+      let inQuotes = false;
+      const safeLength = Math.min(line.length, MAX_CSV_LINE_CHARS);
+      for (let i = 0; i < safeLength; i++) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (inQuotes && line[i + 1] === '"') {
+            current += '"';
+            i++;
+          } else {
+            inQuotes = !inQuotes;
+          }
+        } else if (ch === ',' && !inQuotes) {
+          result.push(current.trim());
+          current = '';
+        } else {
+          current += ch;
+        }
+      }
+      result.push(current.trim());
+      return result;
+    }
+
+    rawHeaders = parseCsvLine(lines[0]);
+    dataLines2d = lines.slice(1).map((l) => parseCsvLine(l));
+  } // end CSV path
+
   const normalizedHeaders = rawHeaders.map((h) => h.toLowerCase().replace(/\s+/g, '_'));
-  const dataLines = lines.slice(1);
 
   // ── Apply field mapping from the frontend wizard (Story #664, Item 11) ────
   // column_map is sent as a JSON string form field: { csvHeader -> guestField }
@@ -953,8 +993,7 @@ export async function importCsv(req: Request, res: Response): Promise<Response> 
   let imported = 0;
   let skipped = 0;
 
-  for (const line of dataLines) {
-    const values = parseCsvLine(line);
+  for (const values of dataLines2d) {
     // Null-prototype object prevents prototype-chain key collisions in row.
     const row: Record<string, string> = Object.create(null) as Record<string, string>;
     rawHeaders.forEach((rawHeader, i) => {

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -96,15 +96,26 @@ if (!fs.existsSync(DOCUMENTS_DIR)) fs.mkdirSync(DOCUMENTS_DIR, { recursive: true
 const VENDOR_CONTRACTS_DIR = path.resolve('uploads/vendor-contracts');
 if (!fs.existsSync(VENDOR_CONTRACTS_DIR)) fs.mkdirSync(VENDOR_CONTRACTS_DIR, { recursive: true });
 
-// In-memory multer for CSV imports (no disk write needed)
+// In-memory multer for CSV / XLSX imports (no disk write needed)
 const csvUpload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
-    if (file.mimetype === 'text/csv' || file.originalname.toLowerCase().endsWith('.csv')) {
+    const lower = file.originalname.toLowerCase();
+    const acceptedMimes = new Set([
+      'text/csv',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ]);
+    if (
+      acceptedMimes.has(file.mimetype) ||
+      lower.endsWith('.csv') ||
+      lower.endsWith('.xlsx') ||
+      lower.endsWith('.xls')
+    ) {
       cb(null, true);
     } else {
-      cb(new Error('Only CSV files are accepted'));
+      cb(new Error('Only CSV and Excel files (.csv, .xlsx, .xls) are accepted'));
     }
   },
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-hook-form": "^7.76.0",
         "react-router-dom": "^6.30.0",
         "recharts": "^3.8.1",
+        "xlsx": "^0.18.5",
         "zod": "^4.4.3",
         "zustand": "^5.0.13"
       },
@@ -2828,6 +2829,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3005,6 +3015,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3022,6 +3045,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/convert-source-map": {
@@ -3056,6 +3088,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/css-line-break": {
@@ -3491,6 +3535,15 @@
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "license": "MIT"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4738,6 +4791,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5818,6 +5883,45 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.76.0",
     "react-router-dom": "^6.30.0",
     "recharts": "^3.8.1",
+    "xlsx": "^0.18.5",
     "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },

--- a/frontend/src/components/guests/csv-import-dialog.tsx
+++ b/frontend/src/components/guests/csv-import-dialog.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useRef, useState } from 'react';
 import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
 import {
   Alert,
   Box,
@@ -23,6 +24,16 @@ import {
   Typography,
 } from '@mui/material';
 import { importCsv, importCsvTemplateUrl } from '../../services/guest-service';
+
+/** File extensions accepted by the upload input. */
+const ACCEPTED_EXTENSIONS =
+  '.csv,.xlsx,.xls,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel';
+
+/** Returns true when the selected file is an Excel workbook (.xlsx / .xls). */
+function isExcelFile(file: File): boolean {
+  const lower = file.name.toLowerCase();
+  return lower.endsWith('.xlsx') || lower.endsWith('.xls');
+}
 
 // Columns that can be mapped from CSV
 const GUEST_FIELDS = [
@@ -74,36 +85,75 @@ export function CsvImportDialog({
     onClose();
   }
 
+  function applyPreview(rows: string[][]): void {
+    if (rows.length < 2) {
+      setError('File appears empty or has no data rows.');
+      return;
+    }
+    const fileHeaders = rows[0];
+    const dataRows = rows.slice(1, 6);
+    setHeaders(fileHeaders);
+    setPreviewRows(dataRows);
+    // Auto-map headers that match field names (case-insensitive)
+    const autoMap: Record<string, string> = {};
+    fileHeaders.forEach((h) => {
+      const normalised = h.toLowerCase().replace(/\s+/g, '_');
+      const match = GUEST_FIELDS.find((f) => f.value === normalised);
+      autoMap[h] = match ? match.value : '';
+    });
+    setColumnMap(autoMap);
+  }
+
   function handleFileChange(e: ChangeEvent<HTMLInputElement>): void {
     const file = e.target.files?.[0];
     if (!file) return;
     setSelectedFile(file);
     setError(null);
 
-    Papa.parse<string[]>(file, {
-      preview: 6,
-      skipEmptyLines: true,
-      complete: (result) => {
-        const rows = result.data as string[][];
-        if (rows.length < 2) {
-          setError('CSV appears empty or has no data rows.');
-          return;
+    if (isExcelFile(file)) {
+      // Parse with SheetJS — read first 6 rows from the first sheet
+      const reader = new FileReader();
+      reader.onload = (evt) => {
+        try {
+          const data = evt.target?.result;
+          if (!data) {
+            setError('Failed to read Excel file.');
+            return;
+          }
+          const workbook = XLSX.read(data, { type: 'array' });
+          const sheetName = workbook.SheetNames[0];
+          if (!sheetName) {
+            setError('Excel file has no sheets.');
+            return;
+          }
+          const sheet = workbook.Sheets[sheetName];
+          // sheet_to_json with header:1 gives string[][] (first row = headers)
+          const allRows = XLSX.utils.sheet_to_json<string[]>(sheet, {
+            header: 1,
+            defval: '',
+            range: 0,
+          });
+          // Filter out completely empty rows
+          const rows = allRows
+            .filter((r) => r.some((cell) => String(cell ?? '').trim() !== ''))
+            .map((r) => r.map((cell) => String(cell ?? '')));
+          applyPreview(rows);
+        } catch {
+          setError('Failed to parse Excel file. Please check the format.');
         }
-        const csvHeaders = rows[0];
-        const dataRows = rows.slice(1, 6);
-        setHeaders(csvHeaders);
-        setPreviewRows(dataRows);
-        // Auto-map headers that match field names (case-insensitive)
-        const autoMap: Record<string, string> = {};
-        csvHeaders.forEach((h) => {
-          const normalised = h.toLowerCase().replace(/\s+/g, '_');
-          const match = GUEST_FIELDS.find((f) => f.value === normalised);
-          autoMap[h] = match ? match.value : '';
-        });
-        setColumnMap(autoMap);
-      },
-      error: () => setError('Failed to parse CSV file. Please check the format.'),
-    });
+      };
+      reader.onerror = () => setError('Failed to read Excel file.');
+      reader.readAsArrayBuffer(file);
+    } else {
+      Papa.parse<string[]>(file, {
+        preview: 6,
+        skipEmptyLines: true,
+        complete: (result) => {
+          applyPreview(result.data as string[][]);
+        },
+        error: () => setError('Failed to parse CSV file. Please check the format.'),
+      });
+    }
   }
 
   async function handleImport(): Promise<void> {
@@ -125,7 +175,7 @@ export function CsvImportDialog({
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-      <DialogTitle>Import Guests from CSV</DialogTitle>
+      <DialogTitle>Import Guests from CSV / Excel</DialogTitle>
       <DialogContent>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
           {error && <Alert severity="error">{error}</Alert>}
@@ -134,22 +184,22 @@ export function CsvImportDialog({
             <input
               ref={fileInputRef}
               type="file"
-              accept=".csv,text/csv"
+              accept={ACCEPTED_EXTENSIONS}
               style={{ display: 'none' }}
               id="csv-file-input"
-              aria-label="Select CSV file"
+              aria-label="Select CSV or Excel file"
               onChange={handleFileChange}
             />
             <label htmlFor="csv-file-input">
               <Button component="span" variant="outlined">
-                {selectedFile ? selectedFile.name : 'Choose CSV File'}
+                {selectedFile ? selectedFile.name : 'Choose CSV or Excel File'}
               </Button>
             </label>
           </Box>
 
           {headers.length > 0 && (
             <>
-              <Typography variant="subtitle2">Map CSV columns to guest fields:</Typography>
+              <Typography variant="subtitle2">Map columns to guest fields:</Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
                 {headers.map((h) => (
                   <FormControl key={h} size="small" sx={{ minWidth: 180 }}>
@@ -162,7 +212,9 @@ export function CsvImportDialog({
                       }
                     >
                       {GUEST_FIELDS.map((f) => (
-                        <MenuItem key={f.value} value={f.value}>{f.label}</MenuItem>
+                        <MenuItem key={f.value} value={f.value}>
+                          {f.label}
+                        </MenuItem>
                       ))}
                     </Select>
                   </FormControl>
@@ -204,7 +256,9 @@ export function CsvImportDialog({
         >
           Download CSV Template
         </Button>
-        <Button onClick={handleClose} disabled={importing}>Cancel</Button>
+        <Button onClick={handleClose} disabled={importing}>
+          Cancel
+        </Button>
         <Button
           variant="contained"
           disabled={!selectedFile || importing}


### PR DESCRIPTION
## Summary
Adds SheetJS XLSX parsing to the guest import wizard so event managers can import guests from Excel files in addition to CSV.

## Changes
- `backend/src/controllers/rsvps-controller.ts` — detect Excel by MIME/extension, parse with `XLSX.read()` + `sheet_to_json()`, produce unified `dataLines2d` for both CSV and XLSX paths
- `backend/src/routes/api-routes.ts` — multer `csvUpload` filter now accepts `.xlsx`, `.xls` and their MIME types
- `frontend/src/components/guests/csv-import-dialog.tsx` — XLSX preview via `FileReader` + `XLSX.read()`, updated `accept` attribute and dialog title
- `frontend/package.json` / `backend/package.json` — added `xlsx` (SheetJS)

## Testing
- Import a `.xlsx` file → verify column mapping preview loads correctly
- Import a `.csv` file → verify existing behaviour unchanged

Closes #2
Closes #14