### PR TITLE
fix(backend): enable row-level security by default (task 767)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,11 +83,6 @@ ENTRA_GROUP_VIEWERS=00000000-0000-0000-0000-000000000000
 # Get your API key at https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-...
 
-# ---- PostgreSQL RLS Pilot (#421, #472) ----
-# Set to true to enable Row-Level Security policies on events and event_members.
-# Leave false (default) during validation. Safe to toggle without schema changes.
-RLS_PILOT_ENABLED=false
-
 # ---- Frontend (Vite) ----
 # Prefix ALL frontend-visible env vars with VITE_
 # Leave VITE_API_URL empty when running via Docker (nginx proxies /api to the backend)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Task #767 — RLS default-on and pilot flag retirement**: backend migration/runtime no longer depends on `RLS_PILOT_ENABLED`; RLS policies are applied by default, startup now hard-fails in `production`/`staging` if the connecting DB role has `BYPASSRLS`, request middleware now sets both `app.current_user_id` and `app.current_role`, and regression tests now cover at least 3 read paths plus 3 write paths with explicit allow/deny assertions.
 - **Entra group overage fallback for RBAC**: Entra callback now handles group overage tokens (`hasgroups` / `_claim_names.groups`) by fetching group IDs from Microsoft Graph `me/memberOf` when direct `groups` claims are omitted, ensuring role mapping remains accurate for high-membership users.
 - **Secure-environment MFA/auth startup enforcement**: strict startup security controls now require `ENTRA_AUTH_ENABLED=true` and `ENTRA_MFA_REQUIRED=true` in `production`/`staging`, eliminating drift where Entra or MFA could be disabled in secure deployments.
 - **API cache policy evidence**: API GET/HEAD responses now emit explicit cache headers (`Cache-Control: private, max-age=300`) with auth-safe `Vary` headers; integration tests assert the policy.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -61,9 +61,6 @@ ENTRA_GROUP_COLLABORATORS=00000000-0000-0000-0000-000000000000
 ENTRA_GROUP_GUESTS=00000000-0000-0000-0000-000000000000
 ENTRA_GROUP_VIEWERS=00000000-0000-0000-0000-000000000000
 
-# ---- PostgreSQL RLS Pilot ----
-RLS_PILOT_ENABLED=false
-
 # ---- Email Bounce Webhook ----
 # Shared HMAC-SHA256 secret used to verify POST /webhooks/email/bounce.
 # Requests must send X-Amz-SNS-Signature = hex(hmac_sha256(rawBody, secret)).

--- a/backend/__tests__/rls-auto-detect.test.ts
+++ b/backend/__tests__/rls-auto-detect.test.ts
@@ -1,11 +1,9 @@
 /**
- * Regression tests for the RLS auto-detect path added in #702.
+ * Regression tests for the default-on RLS startup gate.
  *
- * `resolveRlsEnabled` is the gate the schema migration uses to decide whether
- * to apply RLS policies (and FORCE ROW LEVEL SECURITY) on event-scoped tables.
- * Getting this wrong silently empties result sets on non-superuser
- * deployments, so the behaviour must stay covered by a unit test that does
- * not require a live PostgreSQL connection.
+ * `resolveRlsEnabled` now always enables RLS and performs a fail-closed check
+ * in secure environments (production/staging): if the connecting role has
+ * BYPASSRLS, startup must fail.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -23,86 +21,75 @@ function stubDb(opts: StubDbOptions = {}): DatabaseAdapter {
       if (opts.bypassrls === null) return undefined as T | undefined;
       return { rolbypassrls: Boolean(opts.bypassrls) } as unknown as T;
     },
-    async all<T = unknown>(_sql: string, _params?: unknown[]): Promise<T[]> { return []; },
-    async run(_sql: string, _params?: unknown[]) { return { lastID: undefined, changes: 0 }; },
-    async exec(_sql: string): Promise<void> { /* noop */ },
+    async all<T = unknown>(_sql: string, _params?: unknown[]): Promise<T[]> {
+      return [];
+    },
+    async run(_sql: string, _params?: unknown[]) {
+      return { lastID: undefined, changes: 0 };
+    },
+    async exec(_sql: string): Promise<void> {
+      /* noop */
+    },
   };
 }
 
-describe('resolveRlsEnabled — #702 RLS auto-detect', () => {
-  const originalEnv = process.env.RLS_PILOT_ENABLED;
+describe('resolveRlsEnabled — #767 RLS default-on + secure fail-closed', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
   let warnSpy: ReturnType<typeof vi.spyOn>;
-  let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    delete process.env.RLS_PILOT_ENABLED;
+    process.env.NODE_ENV = 'development';
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.RLS_PILOT_ENABLED;
-    else process.env.RLS_PILOT_ENABLED = originalEnv;
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
     warnSpy.mockRestore();
-    logSpy.mockRestore();
   });
 
-  it('returns true when RLS_PILOT_ENABLED=true regardless of role attribute', async () => {
-    process.env.RLS_PILOT_ENABLED = 'true';
+  it('returns true in non-secure environments when role does not bypass RLS', async () => {
     await expect(resolveRlsEnabled(stubDb({ bypassrls: false }))).resolves.toBe(true);
   });
 
-  it('returns false when RLS_PILOT_ENABLED=false regardless of role attribute', async () => {
-    process.env.RLS_PILOT_ENABLED = 'false';
-    await expect(resolveRlsEnabled(stubDb({ bypassrls: true }))).resolves.toBe(false);
-  });
-
-  it('auto-enables when role bypasses RLS (policies are inert in dev)', async () => {
+  it('returns true in non-secure environments when role bypasses RLS (with warning)', async () => {
     await expect(resolveRlsEnabled(stubDb({ bypassrls: true }))).resolves.toBe(true);
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[RLS] Auto-enabling policies'),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has BYPASSRLS'));
   });
 
-  it('auto-disables when role does NOT bypass RLS (prevents silent empty result sets)', async () => {
-    await expect(resolveRlsEnabled(stubDb({ bypassrls: false }))).resolves.toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[RLS] Auto-disabling policies'),
-    );
+  it('throws in secure environments when role bypasses RLS', async () => {
+    process.env.NODE_ENV = 'production';
+    await expect(resolveRlsEnabled(stubDb({ bypassrls: true }))).rejects.toThrow(/BYPASSRLS/);
   });
 
-  it('auto-disables with a safety warning when the pg_roles probe throws', async () => {
+  it('throws in secure environments when BYPASSRLS probe fails', async () => {
+    process.env.NODE_ENV = 'staging';
     const err = new Error('permission denied for pg_roles');
-    await expect(resolveRlsEnabled(stubDb({ throwOnGet: err }))).resolves.toBe(false);
+    await expect(resolveRlsEnabled(stubDb({ throwOnGet: err }))).rejects.toThrow(
+      /could not verify BYPASSRLS state/,
+    );
+  });
+
+  it('continues in non-secure environments when BYPASSRLS probe fails', async () => {
+    const err = new Error('permission denied for pg_roles');
+    await expect(resolveRlsEnabled(stubDb({ throwOnGet: err }))).resolves.toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[RLS] Could not determine role BYPASSRLS attribute'),
+      expect.stringContaining('Could not determine role BYPASSRLS attribute'),
       expect.stringContaining('permission denied'),
     );
   });
 
-  it('treats a NULL/undefined probe result as non-bypass (safety)', async () => {
-    await expect(resolveRlsEnabled(stubDb({ bypassrls: null }))).resolves.toBe(false);
+  it('treats a NULL/undefined probe result as non-bypass and keeps RLS enabled', async () => {
+    await expect(resolveRlsEnabled(stubDb({ bypassrls: null }))).resolves.toBe(true);
   });
 
-  it.each(['TRUE', 'True', 'tRuE'])(
-    'parses %s as enabled (case-insensitive)',
-    async (val) => {
-      process.env.RLS_PILOT_ENABLED = val;
-      await expect(resolveRlsEnabled(stubDb({ bypassrls: false }))).resolves.toBe(true);
-    },
-  );
+  it('keeps RLS enabled in secure environments when role does not bypass RLS', async () => {
+    process.env.NODE_ENV = 'production';
+    await expect(resolveRlsEnabled(stubDb({ bypassrls: false }))).resolves.toBe(true);
+  });
 
-  it.each(['FALSE', 'False', 'fAlSe'])(
-    'parses %s as disabled (case-insensitive)',
-    async (val) => {
-      process.env.RLS_PILOT_ENABLED = val;
-      await expect(resolveRlsEnabled(stubDb({ bypassrls: true }))).resolves.toBe(false);
-    },
-  );
-
-  it('treats any non-true/false env value as unset (falls through to probe)', async () => {
-    process.env.RLS_PILOT_ENABLED = 'maybe';
-    // probe says bypassrls=true → auto-enable
+  it('treats unknown NODE_ENV as non-secure and keeps RLS enabled', async () => {
+    process.env.NODE_ENV = 'qa';
     await expect(resolveRlsEnabled(stubDb({ bypassrls: true }))).resolves.toBe(true);
   });
 });

--- a/backend/__tests__/rls-request-context.test.ts
+++ b/backend/__tests__/rls-request-context.test.ts
@@ -1,6 +1,6 @@
 /**
  * Verifies the request-scoped RLS wiring (#702):
- *   - attachUserContext binds a pg client with app.current_user_id set
+ *   - attachUserContext binds a pg client with app.current_user_id/app.current_role set
  *   - getDatabase() queries from within the ALS scope see that GUC
  *   - queries from outside the scope (pool fallback) do NOT see it
  *
@@ -11,11 +11,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import {
-  closeDatabase,
-  getDatabase,
-  initializeDatabase,
-} from '../src/db/database.js';
+import { closeDatabase, getDatabase, initializeDatabase } from '../src/db/database.js';
 import { attachUserContext } from '../src/middleware/attach-user-context.js';
 
 describe('attachUserContext + getDatabase — request-scoped RLS context (#702)', () => {
@@ -27,7 +23,7 @@ describe('attachUserContext + getDatabase — request-scoped RLS context (#702)'
     await closeDatabase();
   });
 
-  function buildApp(userId: number) {
+  function buildApp(userId: number, roleId: number) {
     const app = express();
     // Mount a rate limiter on the test app so the route below isn't flagged
     // by the CodeQL `js/missing-rate-limiting` rule. The limit is huge
@@ -46,7 +42,7 @@ describe('attachUserContext + getDatabase — request-scoped RLS context (#702)'
       (req as express.Request & { user?: { id: number; email: string; role_id: number } }).user = {
         id: userId,
         email: `u${userId}@test.local`,
-        role_id: 1,
+        role_id: roleId,
       };
       next();
     });
@@ -54,48 +50,56 @@ describe('attachUserContext + getDatabase — request-scoped RLS context (#702)'
     app.get('/whoami', async (_req, res) => {
       // Read the GUC visible to the same request — proves the ALS-bound
       // client is being used by PgWrapper.
-      const row = await getDatabase().get<{ uid: string | null }>(
-        `SELECT NULLIF(current_setting('app.current_user_id', true), '') AS uid`,
+      const row = await getDatabase().get<{ uid: string | null; role: string | null }>(
+        `SELECT
+           NULLIF(current_setting('app.current_user_id', true), '') AS uid,
+           NULLIF(current_setting('app.current_role', true), '') AS role`,
       );
-      res.json({ uid: row?.uid ?? null });
+      res.json({ uid: row?.uid ?? null, role: row?.role ?? null });
     });
     return app;
   }
 
   it('sets app.current_user_id on the bound client for the duration of the request', async () => {
-    const app = buildApp(4242);
+    const app = buildApp(4242, 14242);
     const res = await request(app).get('/whoami').expect(200);
     expect(res.body.uid).toBe('4242');
+    expect(res.body.role).toBe('14242');
   });
 
   it('isolates the GUC per request — concurrent requests do not see each other', async () => {
-    const appA = buildApp(11);
-    const appB = buildApp(22);
-    const [a, b] = await Promise.all([
-      request(appA).get('/whoami'),
-      request(appB).get('/whoami'),
-    ]);
+    const appA = buildApp(11, 1011);
+    const appB = buildApp(22, 2022);
+    const [a, b] = await Promise.all([request(appA).get('/whoami'), request(appB).get('/whoami')]);
     expect(a.body.uid).toBe('11');
     expect(b.body.uid).toBe('22');
+    expect(a.body.role).toBe('1011');
+    expect(b.body.role).toBe('2022');
   });
 
   it('falls back to the pool (no GUC) when called outside any request context', async () => {
-    const row = await getDatabase().get<{ uid: string | null }>(
-      `SELECT NULLIF(current_setting('app.current_user_id', true), '') AS uid`,
+    const row = await getDatabase().get<{ uid: string | null; role: string | null }>(
+      `SELECT
+         NULLIF(current_setting('app.current_user_id', true), '') AS uid,
+         NULLIF(current_setting('app.current_role', true), '') AS role`,
     );
     expect(row?.uid ?? null).toBeNull();
+    expect(row?.role).not.toBe('14242');
   });
 
   it('releases the bound client and resets the GUC after the response finishes', async () => {
-    const app = buildApp(99);
+    const app = buildApp(99, 9099);
     await request(app).get('/whoami').expect(200);
     // After response: subsequent pool-borrowed queries must not leak the GUC.
     // We check several times because the released client may be reused.
     for (let i = 0; i < 5; i++) {
-      const row = await getDatabase().get<{ uid: string | null }>(
-        `SELECT NULLIF(current_setting('app.current_user_id', true), '') AS uid`,
+      const row = await getDatabase().get<{ uid: string | null; role: string | null }>(
+        `SELECT
+           NULLIF(current_setting('app.current_user_id', true), '') AS uid,
+           NULLIF(current_setting('app.current_role', true), '') AS role`,
       );
       expect(row?.uid ?? null).toBeNull();
+      expect(row?.role).not.toBe('9099');
     }
   });
 });

--- a/backend/__tests__/rls.test.ts
+++ b/backend/__tests__/rls.test.ts
@@ -76,7 +76,43 @@ async function createRlsTestContext(): Promise<RlsTestContext> {
     )
   `);
 
-  await pool.query(`GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA "${schema}" TO ${RLS_TEST_ROLE}`);
+  await pool.query(`
+    CREATE TABLE "${schema}".tasks (
+      id SERIAL PRIMARY KEY,
+      event_id INTEGER NOT NULL REFERENCES "${schema}".events(id),
+      title TEXT NOT NULL
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE "${schema}".expenses (
+      id SERIAL PRIMARY KEY,
+      event_id INTEGER NOT NULL REFERENCES "${schema}".events(id),
+      title TEXT NOT NULL,
+      amount NUMERIC(10,2) NOT NULL DEFAULT 0
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE "${schema}".vendors (
+      id SERIAL PRIMARY KEY,
+      event_id INTEGER NOT NULL REFERENCES "${schema}".events(id),
+      name TEXT NOT NULL
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE "${schema}".rsvps (
+      id SERIAL PRIMARY KEY,
+      event_id INTEGER NOT NULL REFERENCES "${schema}".events(id),
+      guest_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'Pending'
+    )
+  `);
+
+  await pool.query(
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "${schema}" TO ${RLS_TEST_ROLE}`,
+  );
   await pool.query(`GRANT USAGE ON ALL SEQUENCES IN SCHEMA "${schema}" TO ${RLS_TEST_ROLE}`);
 
   // Enable RLS on pilot tables
@@ -84,6 +120,14 @@ async function createRlsTestContext(): Promise<RlsTestContext> {
   await pool.query(`ALTER TABLE "${schema}".events FORCE ROW LEVEL SECURITY`);
   await pool.query(`ALTER TABLE "${schema}".event_members ENABLE ROW LEVEL SECURITY`);
   await pool.query(`ALTER TABLE "${schema}".event_members FORCE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".tasks ENABLE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".tasks FORCE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".expenses ENABLE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".expenses FORCE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".vendors ENABLE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".vendors FORCE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".rsvps ENABLE ROW LEVEL SECURITY`);
+  await pool.query(`ALTER TABLE "${schema}".rsvps FORCE ROW LEVEL SECURITY`);
 
   // Owner policy: see events you created
   await pool.query(`
@@ -109,6 +153,47 @@ async function createRlsTestContext(): Promise<RlsTestContext> {
     CREATE POLICY rls_event_members_self ON "${schema}".event_members
       USING (
         user_id = NULLIF(current_setting('app.current_user_id', true), '')::int
+      )
+  `);
+
+  await pool.query(`
+    CREATE POLICY rls_tasks_event_member ON "${schema}".tasks
+      USING (
+        event_id IN (
+          SELECT event_id FROM "${schema}".event_members
+          WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::int
+        )
+      )
+  `);
+
+  await pool.query(`
+    CREATE POLICY rls_expenses_event_member ON "${schema}".expenses
+      USING (
+        event_id IN (
+          SELECT event_id FROM "${schema}".event_members
+          WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::int
+        )
+      )
+  `);
+
+  await pool.query(`
+    CREATE POLICY rls_vendors_event_member ON "${schema}".vendors
+      USING (
+        event_id IN (
+          SELECT event_id FROM "${schema}".event_members
+          WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::int
+        )
+      )
+  `);
+
+  await pool.query(`
+    CREATE POLICY rls_rsvps_access ON "${schema}".rsvps
+      USING (
+        event_id IN (
+          SELECT event_id FROM "${schema}".event_members
+          WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::int
+            AND LOWER(role) IN ('organizer', 'admin', 'collaborator', 'owner', 'co-organizer', 'helper')
+        )
       )
   `);
 
@@ -159,7 +244,12 @@ async function seedUser(pool: pg.Pool, schema: string, email: string): Promise<n
   return result.rows[0].id;
 }
 
-async function seedEvent(pool: pg.Pool, schema: string, title: string, createdBy: number): Promise<number> {
+async function seedEvent(
+  pool: pg.Pool,
+  schema: string,
+  title: string,
+  createdBy: number,
+): Promise<number> {
   const result = await pool.query<{ id: number }>(
     `INSERT INTO "${schema}".events (title, created_by) VALUES ($1, $2) RETURNING id`,
     [title, createdBy],
@@ -167,11 +257,55 @@ async function seedEvent(pool: pg.Pool, schema: string, title: string, createdBy
   return result.rows[0].id;
 }
 
-async function addMember(pool: pg.Pool, schema: string, eventId: number, userId: number): Promise<void> {
+async function addMember(
+  pool: pg.Pool,
+  schema: string,
+  eventId: number,
+  userId: number,
+): Promise<void> {
   await pool.query(
     `INSERT INTO "${schema}".event_members (event_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
     [eventId, userId],
   );
+}
+
+async function seedTask(
+  pool: pg.Pool,
+  schema: string,
+  eventId: number,
+  title: string,
+): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO "${schema}".tasks (event_id, title) VALUES ($1, $2) RETURNING id`,
+    [eventId, title],
+  );
+  return result.rows[0].id;
+}
+
+async function seedExpense(
+  pool: pg.Pool,
+  schema: string,
+  eventId: number,
+  title: string,
+): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO "${schema}".expenses (event_id, title, amount) VALUES ($1, $2, $3) RETURNING id`,
+    [eventId, title, 100],
+  );
+  return result.rows[0].id;
+}
+
+async function seedVendor(
+  pool: pg.Pool,
+  schema: string,
+  eventId: number,
+  name: string,
+): Promise<number> {
+  const result = await pool.query<{ id: number }>(
+    `INSERT INTO "${schema}".vendors (event_id, name) VALUES ($1, $2) RETURNING id`,
+    [eventId, name],
+  );
+  return result.rows[0].id;
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -191,7 +325,12 @@ describe('RLS pilot — events table', () => {
     const alice = await seedUser(ctx.pool, ctx.schema, 'alice@example.com');
     await seedEvent(ctx.pool, ctx.schema, 'Alice Event', alice);
 
-    const rows = await queryAsUser(ctx.pool, ctx.schema, alice, `SELECT id, title FROM "${ctx.schema}".events`);
+    const rows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      alice,
+      `SELECT id, title FROM "${ctx.schema}".events`,
+    );
     expect(rows).toHaveLength(1);
     expect(rows[0].title).toBe('Alice Event');
   });
@@ -201,7 +340,12 @@ describe('RLS pilot — events table', () => {
     const bob = await seedUser(ctx.pool, ctx.schema, 'bob@example.com');
     await seedEvent(ctx.pool, ctx.schema, 'Bob Event', bob);
 
-    const rows = await queryAsUser(ctx.pool, ctx.schema, alice, `SELECT id FROM "${ctx.schema}".events`);
+    const rows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      alice,
+      `SELECT id FROM "${ctx.schema}".events`,
+    );
     expect(rows).toHaveLength(0);
   });
 
@@ -212,7 +356,12 @@ describe('RLS pilot — events table', () => {
 
     await addMember(ctx.pool, ctx.schema, eventId, bob);
 
-    const rows = await queryAsUser<{ title: string }>(ctx.pool, ctx.schema, bob, `SELECT title FROM "${ctx.schema}".events`);
+    const rows = await queryAsUser<{ title: string }>(
+      ctx.pool,
+      ctx.schema,
+      bob,
+      `SELECT title FROM "${ctx.schema}".events`,
+    );
     expect(rows).toHaveLength(1);
     expect(rows[0].title).toBe('Alice Event 2');
   });
@@ -222,7 +371,12 @@ describe('RLS pilot — events table', () => {
     const bob = await seedUser(ctx.pool, ctx.schema, 'bob3@example.com');
     await seedEvent(ctx.pool, ctx.schema, 'Private Event', alice);
 
-    const rows = await queryAsUser(ctx.pool, ctx.schema, bob, `SELECT id FROM "${ctx.schema}".events`);
+    const rows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      bob,
+      `SELECT id FROM "${ctx.schema}".events`,
+    );
     expect(rows).toHaveLength(0);
   });
 
@@ -234,7 +388,12 @@ describe('RLS pilot — events table', () => {
     const bobEventId = await seedEvent(ctx.pool, ctx.schema, 'Bob Event 2', bob);
     await addMember(ctx.pool, ctx.schema, bobEventId, alice);
 
-    const rows = await queryAsUser(ctx.pool, ctx.schema, alice, `SELECT id FROM "${ctx.schema}".events ORDER BY id`);
+    const rows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      alice,
+      `SELECT id FROM "${ctx.schema}".events ORDER BY id`,
+    );
     expect(rows).toHaveLength(2);
   });
 });
@@ -250,11 +409,21 @@ describe('RLS pilot — event_members table', () => {
     await addMember(ctx.pool, ctx.schema, eventId, bob);
     await addMember(ctx.pool, ctx.schema, eventId, eve);
 
-    const aliceRows = await queryAsUser(ctx.pool, ctx.schema, alice, `SELECT user_id FROM "${ctx.schema}".event_members`);
+    const aliceRows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      alice,
+      `SELECT user_id FROM "${ctx.schema}".event_members`,
+    );
     expect(aliceRows).toHaveLength(1);
     expect(aliceRows[0].user_id).toBe(alice);
 
-    const bobRows = await queryAsUser(ctx.pool, ctx.schema, bob, `SELECT user_id FROM "${ctx.schema}".event_members`);
+    const bobRows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      bob,
+      `SELECT user_id FROM "${ctx.schema}".event_members`,
+    );
     expect(bobRows).toHaveLength(1);
     expect(bobRows[0].user_id).toBe(bob);
   });
@@ -265,7 +434,12 @@ describe('RLS pilot — event_members table', () => {
     const eventId = await seedEvent(ctx.pool, ctx.schema, 'Event', alice);
     await addMember(ctx.pool, ctx.schema, eventId, alice);
 
-    const rows = await queryAsUser(ctx.pool, ctx.schema, bob, `SELECT * FROM "${ctx.schema}".event_members`);
+    const rows = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      bob,
+      `SELECT * FROM "${ctx.schema}".event_members`,
+    );
     expect(rows).toHaveLength(0);
   });
 });
@@ -290,5 +464,171 @@ describe('RLS pilot — no context set', () => {
     } finally {
       client.release();
     }
+  });
+});
+
+describe('RLS v2 regression matrix — read/write allow-deny', () => {
+  it('read path #1: tasks visible only to event members', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner1@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member1@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider1@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Read Tasks Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+    await seedTask(ctx.pool, ctx.schema, eventId, 'Task One');
+
+    const allowed = await queryAsUser<{ title: string }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `SELECT title FROM "${ctx.schema}".tasks`,
+    );
+    expect(allowed).toHaveLength(1);
+    expect(allowed[0].title).toBe('Task One');
+
+    const denied = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      outsider,
+      `SELECT title FROM "${ctx.schema}".tasks`,
+    );
+    expect(denied).toHaveLength(0);
+  });
+
+  it('read path #2: expenses visible only to event members', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner2@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member2@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider2@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Read Expenses Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+    await seedExpense(ctx.pool, ctx.schema, eventId, 'Venue Deposit');
+
+    const allowed = await queryAsUser<{ title: string }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `SELECT title FROM "${ctx.schema}".expenses`,
+    );
+    expect(allowed).toHaveLength(1);
+    expect(allowed[0].title).toBe('Venue Deposit');
+
+    const denied = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      outsider,
+      `SELECT title FROM "${ctx.schema}".expenses`,
+    );
+    expect(denied).toHaveLength(0);
+  });
+
+  it('read path #3: vendors visible only to event members', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner3@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member3@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider3@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Read Vendors Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+    await seedVendor(ctx.pool, ctx.schema, eventId, 'Best Catering');
+
+    const allowed = await queryAsUser<{ name: string }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `SELECT name FROM "${ctx.schema}".vendors`,
+    );
+    expect(allowed).toHaveLength(1);
+    expect(allowed[0].name).toBe('Best Catering');
+
+    const denied = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      outsider,
+      `SELECT name FROM "${ctx.schema}".vendors`,
+    );
+    expect(denied).toHaveLength(0);
+  });
+
+  it('write path #1: task insert allows members and denies outsiders', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner4@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member4@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider4@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Write Task Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+
+    const inserted = await queryAsUser<{ title: string }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `INSERT INTO "${ctx.schema}".tasks (event_id, title) VALUES ($1, $2) RETURNING title`,
+      [eventId, 'Member Inserted Task'],
+    );
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].title).toBe('Member Inserted Task');
+
+    await expect(
+      queryAsUser(
+        ctx.pool,
+        ctx.schema,
+        outsider,
+        `INSERT INTO "${ctx.schema}".tasks (event_id, title) VALUES ($1, $2) RETURNING id`,
+        [eventId, 'Outsider Task'],
+      ),
+    ).rejects.toThrow(/row-level security policy/i);
+  });
+
+  it('write path #2: expense update allows members and denies outsiders', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner5@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member5@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider5@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Write Expense Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+    const expenseId = await seedExpense(ctx.pool, ctx.schema, eventId, 'Floral');
+
+    const updated = await queryAsUser<{ title: string }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `UPDATE "${ctx.schema}".expenses SET title = $1 WHERE id = $2 RETURNING title`,
+      ['Floral Updated', expenseId],
+    );
+    expect(updated).toHaveLength(1);
+    expect(updated[0].title).toBe('Floral Updated');
+
+    const denied = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      outsider,
+      `UPDATE "${ctx.schema}".expenses SET title = $1 WHERE id = $2 RETURNING id`,
+      ['Outsider Update', expenseId],
+    );
+    expect(denied).toHaveLength(0);
+  });
+
+  it('write path #3: vendor delete allows members and denies outsiders', async () => {
+    const owner = await seedUser(ctx.pool, ctx.schema, 'owner6@example.com');
+    const member = await seedUser(ctx.pool, ctx.schema, 'member6@example.com');
+    const outsider = await seedUser(ctx.pool, ctx.schema, 'outsider6@example.com');
+    const eventId = await seedEvent(ctx.pool, ctx.schema, 'Write Vendor Event', owner);
+    await addMember(ctx.pool, ctx.schema, eventId, member);
+
+    const deletableVendor = await seedVendor(ctx.pool, ctx.schema, eventId, 'Delete Me Vendor');
+    const protectedVendor = await seedVendor(ctx.pool, ctx.schema, eventId, 'Protected Vendor');
+
+    const deleted = await queryAsUser<{ id: number }>(
+      ctx.pool,
+      ctx.schema,
+      member,
+      `DELETE FROM "${ctx.schema}".vendors WHERE id = $1 RETURNING id`,
+      [deletableVendor],
+    );
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0].id).toBe(deletableVendor);
+
+    const denied = await queryAsUser(
+      ctx.pool,
+      ctx.schema,
+      outsider,
+      `DELETE FROM "${ctx.schema}".vendors WHERE id = $1 RETURNING id`,
+      [protectedVendor],
+    );
+    expect(denied).toHaveLength(0);
   });
 });

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -945,41 +945,44 @@ export async function closeDatabase(): Promise<void> {
 }
 
 export async function resolveRlsEnabled(db: DatabaseAdapter): Promise<boolean> {
-  // Explicit env wins (true or false). Default keeps RLS on the safe path:
-  // policies are only applied when the connecting role bypasses RLS, so
-  // policies are effectively no-ops until controllers set
-  // `app.current_user_id` via `withUserContext`. This prevents the migration
-  // from silently emptying result sets on a hardened non-superuser deployment.
-  const explicit = process.env.RLS_PILOT_ENABLED?.toLowerCase();
-  if (explicit === 'true') return true;
-  if (explicit === 'false') return false;
+  const secureEnv = isSecureDeploymentEnv(process.env.NODE_ENV);
 
   try {
     const row = await db.get<{ rolbypassrls: boolean }>(
       `SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user`,
     );
     const bypasses = Boolean(row?.rolbypassrls);
-    if (bypasses) {
-      console.log(
-        '[RLS] Auto-enabling policies: current DB role bypasses RLS, so policies are inert until per-request context is wired in.',
-      );
-    } else {
-      console.warn(
-        '[RLS] Auto-disabling policies: current DB role is not BYPASSRLS and `app.current_user_id` is not yet set per-request. Set RLS_PILOT_ENABLED=true to force-enable once `withUserContext` is adopted in all controllers.',
+
+    if (secureEnv && bypasses) {
+      throw new Error(
+        '[RLS] Startup blocked: production/staging DB role has BYPASSRLS. Use a non-BYPASSRLS role.',
       );
     }
-    return bypasses;
+
+    if (bypasses) {
+      console.warn(
+        '[RLS] Current DB role has BYPASSRLS. RLS remains enabled, but this role bypasses policy enforcement.',
+      );
+    }
+
+    return true;
   } catch (err) {
+    if (secureEnv) {
+      throw new Error(
+        `[RLS] Startup blocked: could not verify BYPASSRLS state in secure environment: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
     console.warn(
-      '[RLS] Could not determine role BYPASSRLS attribute; defaulting to disabled for safety:',
+      '[RLS] Could not determine role BYPASSRLS attribute in non-secure env; continuing with RLS enabled:',
       err instanceof Error ? err.message : err,
     );
-    return false;
+    return true;
   }
 }
 
 async function runMigrations(db: DatabaseAdapter): Promise<void> {
-  const isRlsEnabled = await resolveRlsEnabled(db);
+  await resolveRlsEnabled(db);
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS users (
@@ -1970,9 +1973,9 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_entra_oid ON users(entra_oid) WHERE entra_oid IS NOT NULL`,
   );
 
-  // ── RLS pilot: enable row-level security (#472) ───────────────────────────
-  if (isRlsEnabled) {
-    console.log('[RLS] Applying RLS pilot policies on events and event_members…');
+  // ── RLS default-on: enable row-level security (#472, #767) ───────────────
+  {
+    console.log('[RLS] Applying RLS policies on events and event_members…');
 
     await db.exec(`ALTER TABLE events ENABLE ROW LEVEL SECURITY`);
     await db.exec(`ALTER TABLE events FORCE ROW LEVEL SECURITY`);
@@ -2021,12 +2024,12 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
       END $$;
     `);
 
-    console.log('[RLS] RLS pilot policies applied.');
+    console.log('[RLS] RLS policies for events and event_members applied.');
   }
 
   // ── RLS v2: extend RLS to tasks, expenses, vendors, rsvps (#564, #632, #633) ──
-  if (isRlsEnabled) {
-    console.log('[RLS] Applying RLS v2 policies on tasks, expenses, vendors, rsvps…');
+  {
+    console.log('[RLS] Applying RLS policies on tasks, expenses, vendors, rsvps…');
     for (const tbl of ['tasks', 'expenses', 'vendors', 'rsvps']) {
       await db.exec(`ALTER TABLE ${tbl} ENABLE ROW LEVEL SECURITY`);
       await db.exec(`ALTER TABLE ${tbl} FORCE ROW LEVEL SECURITY`);
@@ -2092,33 +2095,7 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
         END IF;
       END $$;
     `);
-    console.log('[RLS] RLS v2 policies applied.');
-  } else {
-    // When RLS resolves to disabled at startup we must also clear any prior
-    // ENABLE/FORCE state on the tables, otherwise a previously-RLS-enabled
-    // database keeps enforcing the policies even though we no longer manage
-    // them — which is the exact silent-empty-result bug we are guarding
-    // against. We only DISABLE; the policy definitions themselves are kept
-    // in place so re-enabling later (via RLS_PILOT_ENABLED=true) restores
-    // the same access matrix.
-    const rlsTables = ['events', 'event_members', 'tasks', 'expenses', 'vendors', 'rsvps'];
-    for (const tbl of rlsTables) {
-      await db.exec(`
-        DO $$ BEGIN
-          IF EXISTS (
-            SELECT 1 FROM pg_class c
-            JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE n.nspname = 'public'
-              AND c.relname = '${tbl}'
-              AND (c.relrowsecurity = true OR c.relforcerowsecurity = true)
-          ) THEN
-            ALTER TABLE ${tbl} NO FORCE ROW LEVEL SECURITY;
-            ALTER TABLE ${tbl} DISABLE ROW LEVEL SECURITY;
-            RAISE NOTICE '[RLS] Disabled row-level security on %', '${tbl}';
-          END IF;
-        END $$;
-      `);
-    }
+    console.log('[RLS] RLS policies on tasks, expenses, vendors, rsvps applied.');
   }
 
   // ── Guest merge audit (#411, #435) ───────────────────────────────────────
@@ -3146,9 +3123,8 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
   // The v10 schema added task_assignees, task_escalation_rules, the
   // timeline_templates pair, and entity_change_history without RLS. Apply
   // the same fail-open-on-no-context pattern used by v2 so RLS coverage
-  // matches the rest of the event-scoped surface. Gated on isRlsEnabled so
-  // a deployment that has explicitly opted out doesn't get policies forced.
-  if (isRlsEnabled) {
+  // matches the rest of the event-scoped surface.
+  {
     console.log('[RLS] Applying v12 policies on v10 tables…');
 
     // Missing FK index flagged alongside the policy gap.
@@ -3253,31 +3229,5 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
     `);
 
     console.log('[RLS] v12 policies applied.');
-  } else {
-    // Mirror the v2 "disable cleanly when RLS is off" behaviour so a
-    // formerly-enabled DB doesn't keep enforcing the new policies.
-    for (const tbl of [
-      'task_assignees',
-      'task_escalation_rules',
-      'timeline_templates',
-      'timeline_template_items',
-      'entity_change_history',
-    ]) {
-      await db.exec(`
-        DO $$ BEGIN
-          IF EXISTS (
-            SELECT 1 FROM pg_class c
-            JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE n.nspname = 'public'
-              AND c.relname = '${tbl}'
-              AND (c.relrowsecurity = true OR c.relforcerowsecurity = true)
-          ) THEN
-            ALTER TABLE ${tbl} NO FORCE ROW LEVEL SECURITY;
-            ALTER TABLE ${tbl} DISABLE ROW LEVEL SECURITY;
-            RAISE NOTICE '[RLS] Disabled row-level security on %', '${tbl}';
-          END IF;
-        END $$;
-      `);
-    }
   }
 }

--- a/backend/src/middleware/attach-user-context.ts
+++ b/backend/src/middleware/attach-user-context.ts
@@ -72,6 +72,7 @@ export async function attachUserContext(
     released = true;
     client
       .query('RESET app.current_user_id')
+      .then(() => client.query('RESET app.current_role'))
       .catch(() => undefined)
       .finally(() => {
         try {
@@ -87,9 +88,13 @@ export async function attachUserContext(
       'app.current_user_id',
       String(req.user.id),
     ]);
+    await client.query('SELECT set_config($1, $2, false)', [
+      'app.current_role',
+      String(req.user.role_id),
+    ]);
   } catch (err) {
     console.warn(
-      '[RLS] Could not set app.current_user_id; proceeding without RLS binding:',
+      '[RLS] Could not set request RLS context (app.current_user_id/app.current_role); proceeding without RLS binding:',
       err instanceof Error ? err.message : err,
     );
     cleanup();

--- a/database/init.sql
+++ b/database/init.sql
@@ -1168,7 +1168,7 @@ CREATE INDEX IF NOT EXISTS idx_slideshow_items_slideshow_id ON slideshow_items(s
 
 -- ============================================================
 -- RLS pilot: row-level security on events and event_members (#472)
--- Applied only when RLS_PILOT_ENABLED=true at bootstrap time.
+-- Applied by default at bootstrap time.
 -- The application runtime migration also handles this.
 -- ============================================================
 

--- a/database/migrations/v15-rls-default-on.sql
+++ b/database/migrations/v15-rls-default-on.sql
@@ -1,0 +1,36 @@
+-- v15-rls-default-on.sql
+-- Task #767: enable RLS by default and retire runtime pilot toggles.
+--
+-- This migration is idempotent. It ensures all currently managed event-scoped
+-- tables stay in ENABLE + FORCE RLS mode.
+
+DO $$
+DECLARE
+  tbl text;
+BEGIN
+  FOREACH tbl IN ARRAY ARRAY[
+    'events',
+    'event_members',
+    'tasks',
+    'expenses',
+    'vendors',
+    'rsvps',
+    'task_assignees',
+    'task_escalation_rules',
+    'timeline_templates',
+    'timeline_template_items',
+    'entity_change_history'
+  ]
+  LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname = tbl
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', tbl);
+      EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', tbl);
+    END IF;
+  END LOOP;
+END $$;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
       - ENTRA_GROUP_COLLABORATORS=${ENTRA_GROUP_COLLABORATORS:-}
       - ENTRA_GROUP_GUESTS=${ENTRA_GROUP_GUESTS:-}
       - ENTRA_GROUP_VIEWERS=${ENTRA_GROUP_VIEWERS:-}
-      - RLS_PILOT_ENABLED=${RLS_PILOT_ENABLED:-false}
     depends_on:
       db:
         condition: service_healthy

--- a/docs/postgrest-pilot.md
+++ b/docs/postgrest-pilot.md
@@ -18,7 +18,7 @@ PostgREST auto-generates a REST API directly from PostgreSQL schema and enforces
 
 The PostgREST pilot must NOT begin until:
 
-- [ ] RLS policies on `events` and `event_members` are deployed and validated (`RLS_PILOT_ENABLED=true` in production)
+- [ ] RLS policies on `events` and `event_members` are deployed and validated in production
 - [ ] RLS integration tests (#474) are passing in CI
 - [ ] Schema drift between `init.sql` and runtime is resolved (#475)
 - [ ] At least one production traffic cycle has been observed with RLS enabled and no unauthorized data leakage
@@ -28,15 +28,16 @@ The PostgREST pilot must NOT begin until:
 ## Candidate Pilot Endpoints
 
 The following read-only endpoints are low-risk candidates because:
+
 1. They are already backed by RLS policies
 2. They are read-only (GET) — no write path risk during the pilot
 3. They correspond to tables with well-defined ownership rules
 
-| PostgREST Endpoint | Replaces Express Route | RLS Policy |
-|---|---|---|
-| `GET /rest/events` | `GET /api/events` | `rls_events_owner` + `rls_events_member` |
-| `GET /rest/events?id=eq.:id` | `GET /api/events/:id` | same |
-| `GET /rest/event_members?event_id=eq.:id` | part of `GET /api/events/:id/members` | `rls_event_members_self` |
+| PostgREST Endpoint                        | Replaces Express Route                | RLS Policy                               |
+| ----------------------------------------- | ------------------------------------- | ---------------------------------------- |
+| `GET /rest/events`                        | `GET /api/events`                     | `rls_events_owner` + `rls_events_member` |
+| `GET /rest/events?id=eq.:id`              | `GET /api/events/:id`                 | same                                     |
+| `GET /rest/event_members?event_id=eq.:id` | part of `GET /api/events/:id/members` | `rls_event_members_self`                 |
 
 ---
 
@@ -45,6 +46,7 @@ The following read-only endpoints are low-risk candidates because:
 PostgREST must set the PostgreSQL session variable `app.current_user_id` to the authenticated user's ID before executing any query. This is equivalent to what the Express `withUserContext` method does.
 
 Recommended approach:
+
 1. Issue a **PostgREST JWT** from the Express auth layer (signed with the same key or a PostgREST-specific key)
 2. Configure PostgREST to extract the `sub` claim and call `SET LOCAL app.current_user_id = sub` via a pre-request hook
 3. Alternatively, use the `jwt.claims.user_id` PostgREST hook with a `pre-request` stored procedure
@@ -66,24 +68,24 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 ## Rollout Boundary
 
-| Scope | Included in pilot | Rationale |
-|---|---|---|
-| Read-only event list / detail | YES | Low risk, RLS validated |
-| Read-only event membership | YES | Scoped by user_id |
-| Event write (create / update / delete) | NO | Keep in Express until pilot matures |
-| RSVPs, tasks, budget, vendors | NO | RLS policies not yet applied to these tables |
-| Admin endpoints | NO | Bypass RLS by design; not suitable for PostgREST |
+| Scope                                  | Included in pilot | Rationale                                        |
+| -------------------------------------- | ----------------- | ------------------------------------------------ |
+| Read-only event list / detail          | YES               | Low risk, RLS validated                          |
+| Read-only event membership             | YES               | Scoped by user_id                                |
+| Event write (create / update / delete) | NO                | Keep in Express until pilot matures              |
+| RSVPs, tasks, budget, vendors          | NO                | RLS policies not yet applied to these tables     |
+| Admin endpoints                        | NO                | Bypass RLS by design; not suitable for PostgREST |
 
 ---
 
 ## Risks
 
-| Risk | Mitigation |
-|---|---|
-| RLS bypass via function with SECURITY DEFINER | Audit all DB functions; avoid SECURITY DEFINER in pilot tables |
-| PostgREST version compatibility | Pin PostgREST version; test against staging DB first |
-| N+1 queries from client over-fetching | Define PostgREST views with embedded selects; set row limits |
-| Dual API surface confusion (Express + PostgREST) | Document clearly; route PostgREST under `/rest/` prefix |
+| Risk                                             | Mitigation                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------- |
+| RLS bypass via function with SECURITY DEFINER    | Audit all DB functions; avoid SECURITY DEFINER in pilot tables |
+| PostgREST version compatibility                  | Pin PostgREST version; test against staging DB first           |
+| N+1 queries from client over-fetching            | Define PostgREST views with embedded selects; set row limits   |
+| Dual API surface confusion (Express + PostgREST) | Document clearly; route PostgREST under `/rest/` prefix        |
 
 ---
 

--- a/docs/processes/brd-v2-migration-runbook.md
+++ b/docs/processes/brd-v2-migration-runbook.md
@@ -10,15 +10,15 @@
 
 BRD v2 (Business Requirements Document version 2) delivers the following parity improvements across authentication, RBAC, Row Level Security, and the audit subsystem:
 
-| Area | What Changed | Issues |
-|------|-------------|--------|
-| 5-Role Model | Added Collaborator (4), Guest (5), Viewer (6) roles | #537, #573 |
-| Audit Log | Extended `audit_log` with actor_id, target_type, target_id, context, severity | #538, #572 |
-| Audit Coverage | Added audit events for login, logout, session expiry, role change, token refresh, upload scans | #538, #572 |
-| Session Policy | 30-min inactivity timeout enforced; SESSION_EXPIRED audit events emitted | #536, #571 |
-| RLS Extension | Enabled RLS on tasks, expenses, vendors, rsvps | #564, #632, #633 |
-| Upload Scanning | Virus scanning on all file uploads (profile photos, event documents) | #565, #634 |
-| Frontend RBAC | Role checks use role names (not IDs); Collaborator/Viewer support added | #535, #573 |
+| Area            | What Changed                                                                                   | Issues           |
+| --------------- | ---------------------------------------------------------------------------------------------- | ---------------- |
+| 5-Role Model    | Added Collaborator (4), Guest (5), Viewer (6) roles                                            | #537, #573       |
+| Audit Log       | Extended `audit_log` with actor_id, target_type, target_id, context, severity                  | #538, #572       |
+| Audit Coverage  | Added audit events for login, logout, session expiry, role change, token refresh, upload scans | #538, #572       |
+| Session Policy  | 30-min inactivity timeout enforced; SESSION_EXPIRED audit events emitted                       | #536, #571       |
+| RLS Extension   | Enabled RLS on tasks, expenses, vendors, rsvps                                                 | #564, #632, #633 |
+| Upload Scanning | Virus scanning on all file uploads (profile photos, event documents)                           | #565, #634       |
+| Frontend RBAC   | Role checks use role names (not IDs); Collaborator/Viewer support added                        | #535, #573       |
 
 ---
 
@@ -88,16 +88,15 @@ The Node.js backend applies BRD v2 changes at startup via `backend/src/db/databa
 
 1. **5-Role INSERT**: Upserts all 6 roles on every startup (idempotent)
 2. **Audit Column Migrations**: `ALTER TABLE IF NOT EXISTS` blocks run on startup
-3. **RLS v2**: Enabled when `RLS_PILOT_ENABLED=true` — applies policies to tasks/expenses/vendors/rsvps in addition to events/event_members
+3. **RLS v2**: Enabled by default — applies policies to tasks/expenses/vendors/rsvps in addition to events/event_members
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `RLS_PILOT_ENABLED` | `false` | Enable Row Level Security on data tables |
-| `SESSION_TIMEOUT_MS` | `1800000` (30 min) | Inactivity session timeout |
-| `VIRUS_SCAN_ENABLED` | `false` | Enable ClamAV virus scanning on uploads |
-| `VIRUS_SCAN_BLOCK_ON_ERROR` | `false` | Fail-closed on scanner errors (production hardening) |
+| Variable                    | Default            | Description                                          |
+| --------------------------- | ------------------ | ---------------------------------------------------- |
+| `SESSION_TIMEOUT_MS`        | `1800000` (30 min) | Inactivity session timeout                           |
+| `VIRUS_SCAN_ENABLED`        | `false`            | Enable ClamAV virus scanning on uploads              |
+| `VIRUS_SCAN_BLOCK_ON_ERROR` | `false`            | Fail-closed on scanner errors (production hardening) |
 
 ---
 
@@ -124,6 +123,7 @@ await logAuditEvent({
 **Severity Levels**: `INFO | WARN | ERROR | CRITICAL`
 
 **Covered Events**:
+
 - LOGIN_SUCCESS / LOGIN_FAILURE / LOGIN_ACCOUNT_LOCKED
 - LOGOUT / LOGOUT_ALL_SESSIONS
 - TOKEN_REFRESH_SUCCESS / TOKEN_REFRESH_FAILURE
@@ -146,9 +146,9 @@ Frontend role checks use `frontend/src/utils/roles.ts`:
 ```typescript
 import { canEditEvent, isAdmin, isViewOnly } from '../../utils/roles';
 
-const canEdit = canEditEvent(user.roleName);  // Organizer, Admin, Collaborator
-const admin = isAdmin(user.roleName);          // Admin only
-const readOnly = isViewOnly(user.roleName);    // Viewer or Guest
+const canEdit = canEditEvent(user.roleName); // Organizer, Admin, Collaborator
+const admin = isAdmin(user.roleName); // Admin only
+const readOnly = isViewOnly(user.roleName); // Viewer or Guest
 ```
 
 **Do NOT use `user.roleId >= N` comparisons** — role IDs are not ordinal with BRD v2.
@@ -164,6 +164,7 @@ File uploads are scanned via `backend/src/utils/virus-scan.ts`:
 - **Fail-closed** (`VIRUS_SCAN_BLOCK_ON_ERROR=true`): scanner errors reject the upload
 
 Covered upload endpoints:
+
 - `POST /api/profile/photo` (profile photos)
 - `POST /api/events/:eventId/documents` (event documents)
 
@@ -190,8 +191,8 @@ cd frontend && npm run build
 - [ ] Apply `database/migrations/v2-brd-auth-rbac-rls-parity.sql` to target DB
 - [ ] Verify all 6 roles exist: `SELECT id, name FROM roles ORDER BY id;`
 - [ ] Verify audit_log columns: `\d audit_log` in psql
-- [ ] Set `RLS_PILOT_ENABLED=true` if RLS enforcement is desired
+- [ ] Verify startup role does not have `BYPASSRLS` in production/staging
 - [ ] (Optional) Set `VIRUS_SCAN_ENABLED=true` and ensure `clamscan` is installed
 - [ ] (Optional) Set `VIRUS_SCAN_BLOCK_ON_ERROR=true` for fail-closed upload policy
 - [ ] Run backend tests: `cd backend && npm test`
-- [ ] Deploy backend, verify startup logs show `[RLS] RLS v2 policies applied.` if enabled
+- [ ] Deploy backend, verify startup logs show `[RLS] RLS policies on tasks, expenses, vendors, rsvps applied.`


### PR DESCRIPTION
Summary
- remove RLS_PILOT_ENABLED gating and keep RLS enabled by default
- add secure-environment startup hard-fail when DB role has BYPASSRLS
- set both app.current_user_id and app.current_role in request RLS context
- add database/migrations/v15-rls-default-on.sql to enforce default-on RLS state
- extend RLS regression coverage to include at least 3 read paths and 3 write paths with allow/deny assertions
- remove retired env flag from .env.example, backend/.env.example, and docker-compose.yml
- update related docs and add CHANGELOG entry

Validation
- cd backend && npm run lint (passes with existing warnings only)
- cd backend && npx vitest run __tests__/rls-auto-detect.test.ts __tests__/rls-request-context.test.ts __tests__/rls.test.ts

Notes
- cd backend && npm run build currently fails due pre-existing unrelated issues in src/controllers/rsvps-controller.ts (missing exceljs types and implicit any)

Related work item: task 767 under story #763.