### PR TITLE
chore(ci): stop auto-creating draft PRs as github-actions[bot] #854

### DIFF
--- a/.github/workflows/auto-draft-pr.yml
+++ b/.github/workflows/auto-draft-pr.yml
@@ -1,10 +1,12 @@
 name: Auto Create Draft PR
 
+# Disabled: the previous `push` trigger caused auto-created PRs to be authored
+# by `github-actions[bot]` instead of the engineer pushing the branch. The
+# workflow is retained for reference and can still be invoked manually via the
+# Actions tab. To re-enable automatic draft-PR creation, restore the `push`
+# trigger and supply a user-scoped PAT so PRs are attributed to a person.
 on:
-  push:
-    branches:
-      - 'feature/**'
-      - 'bugfix/**'
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
Closes #854. Disables the `push`-triggered `Auto Create Draft PR` workflow whose `gh pr create` invocation runs with the workflow `GITHUB_TOKEN` — which was attributing every auto-opened PR to `github-actions[bot]` instead of the engineer pushing the branch. The workflow file is retained and can still be invoked manually via `workflow_dispatch`, so the behaviour is reversible (re-enable with a user-scoped PAT if desired).

## Acceptance criteria
- [x] Auto-creation of draft PRs on `feature/**`/`bugfix/**` push is disabled
- [x] Workflow remains accessible via `workflow_dispatch`
- [x] Future engineer-pushed branches will result in PRs authored by the engineer

## Test plan
- [x] Workflow YAML parses (verified via the existing CI runner)
- [ ] After merge: push a new `feature/N-*` branch and confirm no PR is auto-created

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)