### PR TITLE
feat(auth): gate demo-credentials banner on Entra + NODE_ENV #782

### DIFF
--- a/e2e/entra-login.spec.ts
+++ b/e2e/entra-login.spec.ts
@@ -59,3 +59,39 @@ test.describe('Login form — Entra modes (#781)', () => {
     await expect(page.getByTestId('entra-sign-in')).toHaveCount(0);
   });
 });
+
+/**
+ * #782 — Demo-credentials banner must never render when Entra is the active
+ * identity path. Covers both the entra-only and entra-with-fallback modes,
+ * since the banner historically leaked into the fallback form too.
+ */
+test.describe('Login form — demo credentials banner gating (#782)', () => {
+  test('entra-only mode hides the demo credentials banner', async ({ page, context }) => {
+    await stubEntraConfig(context, { enabled: true, allowLocalFallback: false });
+
+    await page.goto('/login');
+
+    await expect(page.getByTestId('entra-sign-in')).toBeVisible();
+    await expect(page.getByTestId('demo-credentials-banner')).toHaveCount(0);
+    await expect(page.getByText(/demo credentials/i)).toHaveCount(0);
+  });
+
+  test('entra + fallback hides the demo banner even after revealing the local form', async ({
+    page,
+    context,
+  }) => {
+    await stubEntraConfig(context, { enabled: true, allowLocalFallback: true });
+
+    await page.goto('/login');
+
+    const disclosure = page.getByTestId('local-fallback-disclosure');
+    await expect(disclosure).toBeVisible();
+    await disclosure.click();
+
+    // Local form is now visible, but the demo banner must remain hidden
+    // because Entra is the configured identity path.
+    await expect(page.getByLabel(/^password$/i)).toBeVisible();
+    await expect(page.getByTestId('demo-credentials-banner')).toHaveCount(0);
+    await expect(page.getByText(/demo credentials/i)).toHaveCount(0);
+  });
+});

--- a/frontend/src/components/login-form/login-form.tsx
+++ b/frontend/src/components/login-form/login-form.tsx
@@ -106,6 +106,14 @@ export function LoginForm({ onForgotPassword, onLogin, onRegister }: LoginFormPr
   const localFormVisible =
     configStatus === 'ready' && (!entraEnabled || (allowLocalFallback && showLocalForm));
 
+  // #782 — the demo-credentials banner is a developer affordance only. It
+  // must never render when Entra is the active identity path, nor in any
+  // production build, even if the operator has opted into local fallback.
+  // We read NODE_ENV (replaced at build time by Vite) so the check works both
+  // in production bundles and in vitest's dev-mode runtime.
+  const showDemoCredentials =
+    localFormVisible && !entraEnabled && process.env.NODE_ENV !== 'production';
+
   function handleEmailChange(event: ChangeEvent<HTMLInputElement>) {
     setEmail(event.target.value);
   }
@@ -286,29 +294,32 @@ export function LoginForm({ onForgotPassword, onLogin, onRegister }: LoginFormPr
               </Typography>
             )}
 
-            <Paper
-              variant="outlined"
-              sx={{
-                p: 2,
-                bgcolor: '#f0f4ff',
-                borderColor: '#c7d2fe',
-                borderRadius: 2,
-              }}
-            >
-              <Typography
-                variant="caption"
-                fontWeight={700}
-                sx={{ letterSpacing: 1, display: 'block', mb: 1, color: '#3730a3' }}
+            {showDemoCredentials && (
+              <Paper
+                variant="outlined"
+                data-testid="demo-credentials-banner"
+                sx={{
+                  p: 2,
+                  bgcolor: '#f0f4ff',
+                  borderColor: '#c7d2fe',
+                  borderRadius: 2,
+                }}
               >
-                DEMO CREDENTIALS
-              </Typography>
-              <Typography variant="body2" sx={{ mb: 0.5 }}>
-                <strong>Admin:</strong>&nbsp; admin@festival.local / festivalAdmin2025
-              </Typography>
-              <Typography variant="body2">
-                <strong>User:</strong>&nbsp;&nbsp;&nbsp;&nbsp; user@festival.local / userPass2025
-              </Typography>
-            </Paper>
+                <Typography
+                  variant="caption"
+                  fontWeight={700}
+                  sx={{ letterSpacing: 1, display: 'block', mb: 1, color: '#3730a3' }}
+                >
+                  DEMO CREDENTIALS
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 0.5 }}>
+                  <strong>Admin:</strong>&nbsp; admin@festival.local / festivalAdmin2025
+                </Typography>
+                <Typography variant="body2">
+                  <strong>User:</strong>&nbsp;&nbsp;&nbsp;&nbsp; user@festival.local / userPass2025
+                </Typography>
+              </Paper>
+            )}
           </>
         )}
       </Stack>

--- a/frontend/test/__snapshots__/login-form.test.tsx.snap
+++ b/frontend/test/__snapshots__/login-form.test.tsx.snap
@@ -1,0 +1,542 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`LoginForm — demo credentials banner (#782) > hides the demo banner when Entra is disabled but the build is production (prod no-entra) 1`] = `
+<div>
+  <form
+    class="MuiBox-root css-0"
+    novalidate=""
+  >
+    <div
+      class="MuiStack-root css-lbjakd-MuiStack-root"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="email"
+          id="email-label"
+        >
+          Email
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Email address"
+            autocomplete="email"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="email"
+            name="email"
+            placeholder="your.email@festival.local"
+            required=""
+            type="email"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Email
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="password"
+          id="password-label"
+        >
+          Password
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Password"
+            autocomplete="current-password"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="password"
+            name="password"
+            placeholder="Enter your password"
+            required=""
+            type="password"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Password
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-vuhw6e-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+        >
+          <input
+            aria-label="Remember me"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+            data-indeterminate="false"
+            type="checkbox"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+        >
+          Remember me
+        </span>
+      </label>
+      <button
+        aria-label="Log in"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-cqa794-MuiButtonBase-root-MuiButton-root"
+        disabled=""
+        tabindex="-1"
+        type="submit"
+      >
+        Sign In
+      </button>
+      <p
+        aria-live="polite"
+        class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
+      >
+        Use your email and password to sign in.
+      </p>
+      <button
+        aria-label="Forgot password"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-dw6t5j-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        Forgot password?
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`LoginForm — demo credentials banner (#782) > hides the demo banner when Entra is enabled (entra-on) 1`] = `
+<div>
+  <form
+    class="MuiBox-root css-0"
+    novalidate=""
+  >
+    <div
+      class="MuiStack-root css-lbjakd-MuiStack-root"
+    >
+      <a
+        aria-label="Sign in with Microsoft"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-wze6j6-MuiButtonBase-root-MuiButton-root"
+        data-testid="entra-sign-in"
+        href="/api/auth/entra/login"
+        tabindex="0"
+      >
+        Sign in with Microsoft
+      </a>
+      <div
+        aria-orientation="horizontal"
+        class="MuiDivider-root MuiDivider-fullWidth MuiDivider-withChildren css-1oljykh-MuiDivider-root"
+        role="separator"
+      >
+        <span
+          class="MuiDivider-wrapper css-1134oje-MuiDivider-wrapper"
+        >
+          or use a local account
+        </span>
+      </div>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="email"
+          id="email-label"
+        >
+          Email
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Email address"
+            autocomplete="email"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="email"
+            name="email"
+            placeholder="your.email@festival.local"
+            required=""
+            type="email"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Email
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="password"
+          id="password-label"
+        >
+          Password
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Password"
+            autocomplete="current-password"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="password"
+            name="password"
+            placeholder="Enter your password"
+            required=""
+            type="password"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Password
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-vuhw6e-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+        >
+          <input
+            aria-label="Remember me"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+            data-indeterminate="false"
+            type="checkbox"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+        >
+          Remember me
+        </span>
+      </label>
+      <button
+        aria-label="Log in"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-cqa794-MuiButtonBase-root-MuiButton-root"
+        disabled=""
+        tabindex="-1"
+        type="submit"
+      >
+        Sign In
+      </button>
+      <p
+        aria-live="polite"
+        class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
+      >
+        Use your email and password to sign in.
+      </p>
+      <button
+        aria-label="Forgot password"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-dw6t5j-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        Forgot password?
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`LoginForm — demo credentials banner (#782) > shows the demo banner when Entra is disabled in a development build (dev no-entra) 1`] = `
+<div>
+  <form
+    class="MuiBox-root css-0"
+    novalidate=""
+  >
+    <div
+      class="MuiStack-root css-lbjakd-MuiStack-root"
+    >
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="email"
+          id="email-label"
+        >
+          Email
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Email address"
+            autocomplete="email"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="email"
+            name="email"
+            placeholder="your.email@festival.local"
+            required=""
+            type="email"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Email
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <div
+        class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="false"
+          for="password"
+          id="password-label"
+        >
+          Password
+          <span
+            aria-hidden="true"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+          >
+             
+            *
+          </span>
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl css-1blp12k-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Password"
+            autocomplete="current-password"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="password"
+            name="password"
+            placeholder="Enter your password"
+            required=""
+            type="password"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-1n64csd-MuiNotchedOutlined-root"
+            >
+              <span>
+                Password
+                 
+                *
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-vuhw6e-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+        >
+          <input
+            aria-label="Remember me"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+            data-indeterminate="false"
+            type="checkbox"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+        >
+          Remember me
+        </span>
+      </label>
+      <button
+        aria-label="Log in"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-cqa794-MuiButtonBase-root-MuiButton-root"
+        disabled=""
+        tabindex="-1"
+        type="submit"
+      >
+        Sign In
+      </button>
+      <p
+        aria-live="polite"
+        class="MuiTypography-root MuiTypography-body2 css-1wle3ir-MuiTypography-root"
+      >
+        Use your email and password to sign in.
+      </p>
+      <button
+        aria-label="Forgot password"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-dw6t5j-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        Forgot password?
+      </button>
+      <div
+        class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded css-uwc26x-MuiPaper-root"
+        data-testid="demo-credentials-banner"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-caption css-vkevyi-MuiTypography-root"
+        >
+          DEMO CREDENTIALS
+        </span>
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-jpkd5o-MuiTypography-root"
+        >
+          <strong>
+            Admin:
+          </strong>
+            admin@festival.local / festivalAdmin2025
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body2 css-7ctihp-MuiTypography-root"
+        >
+          <strong>
+            User:
+          </strong>
+               user@festival.local / userPass2025
+        </p>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/frontend/test/login-form.test.tsx
+++ b/frontend/test/login-form.test.tsx
@@ -115,3 +115,69 @@ describe('LoginForm — Entra-aware rendering (#781)', () => {
     expect(screen.queryByTestId('entra-sign-in')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * #782 — Snapshot coverage for the demo-credentials banner gate.
+ *
+ * The banner must render only when Entra is disabled AND the build is not
+ * production. We exercise the three documented states by stubbing the Entra
+ * config and toggling Vite's `import.meta.env.PROD` flag.
+ */
+describe('LoginForm — demo credentials banner (#782)', () => {
+  beforeEach(() => {
+    mockedApi.get.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Restore NODE_ENV so later cases are not contaminated by a forced mode.
+    vi.unstubAllEnvs();
+  });
+
+  function setProdMode(isProd: boolean): void {
+    vi.stubEnv('NODE_ENV', isProd ? 'production' : 'development');
+  }
+
+  it('hides the demo banner when Entra is enabled (entra-on)', async () => {
+    setProdMode(false);
+    mockEntraConfig({ enabled: true, allowLocalFallback: true });
+
+    const { container } = render(<LoginForm />);
+
+    const disclosure = await screen.findByTestId('local-fallback-disclosure');
+    await userEvent.click(disclosure);
+
+    // Even after the user has revealed the local form, the demo banner must
+    // not appear when Entra is the active identity path.
+    expect(await screen.findByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('demo-credentials-banner')).not.toBeInTheDocument();
+    expect(screen.queryByText(/demo credentials/i)).not.toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('shows the demo banner when Entra is disabled in a development build (dev no-entra)', async () => {
+    setProdMode(false);
+    mockEntraConfig({ enabled: false });
+
+    const { container } = render(<LoginForm />);
+
+    expect(await screen.findByLabelText(/email address/i)).toBeInTheDocument();
+    expect(await screen.findByTestId('demo-credentials-banner')).toBeInTheDocument();
+    expect(screen.getByText(/demo credentials/i)).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('hides the demo banner when Entra is disabled but the build is production (prod no-entra)', async () => {
+    setProdMode(true);
+    mockEntraConfig({ enabled: false });
+
+    const { container } = render(<LoginForm />);
+
+    // Local form still renders (no Entra configured) but the dev-only demo
+    // disclosure must never reach a production bundle.
+    expect(await screen.findByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('demo-credentials-banner')).not.toBeInTheDocument();
+    expect(screen.queryByText(/demo credentials/i)).not.toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the demo-credentials banner whenever Entra is the active identity path (entra-only and entra-with-fallback modes), and whenever `NODE_ENV === 'production'`.
- Adds vitest snapshot coverage for the three required render states (entra-on, dev no-entra, prod no-entra) and Playwright assertions that the banner is absent in both Entra modes.

Closes #782.

## Acceptance Criteria
- [x] Demo-credentials banner renders only when Entra is disabled AND `NODE_ENV !== 'production'`
- [x] Snapshot tests for the three states (entra-on, dev no-entra, prod no-entra)
- [x] E2E test asserts the banner is absent in Entra-on mode

## Implementation notes
- `login-form.tsx`: new `showDemoCredentials` derived flag (`localFormVisible && !entraEnabled && NODE_ENV !== 'production'`). The banner moves inside the conditional with a `data-testid="demo-credentials-banner"` hook for tests.
- The banner remains nested under the existing `localFormVisible` block, so it inherits the `#781` fail-closed behaviour on a config-fetch error.
- Tests stub `NODE_ENV` via `vi.stubEnv` (vitest) and rely on Vite's compile-time substitution in the Playwright build.

## Test plan
- [x] `cd frontend && npm test -- login-form` → 7 passed, 3 snapshots written
- [x] `npm run build` (root) → clean bundle
- [x] `npx eslint` on the three changed files → no new errors (1 pre-existing warning unchanged)
- [x] `tsc -p tsconfig.app.json --noEmit` for the changed files → no new errors (only the pre-existing `src/stores/*` issues remain)
- [x] Verified the wider failing-tests set is identical to the develop baseline (timeline, analytics, messages, shopping, etc. — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)