### PR TITLE
feat(auth): Microsoft Graph group fetch — cache and failure-mode hardening #784

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (Track E — Performance & Observability)
+
+- **Task #784 — Microsoft Graph group fetch — cache and failure-mode hardening**: Added `backend/src/services/graph-groups.ts` implementing an in-memory TTL cache keyed by user OID (default 10 min, configurable via `GRAPH_GROUPS_CACHE_TTL_MS`). On Graph API failure, requests are authorised using last-known cached role for up to 24 hours (`GRAPH_GROUPS_MAX_STALE_MS`); beyond that ceiling, login is refused with HTTP 503. Counter metrics `graph_groups_cache_hit_total`, `graph_groups_cache_miss_total`, `graph_groups_failure_total` exposed via `GET /metrics` in Prometheus text format. `backend/src/controllers/entra-auth-controller.ts` updated to route group-overage fetches through the cache. Unit tests in `backend/__tests__/graph-groups.test.ts` cover happy path, cache hit, stale fallback within ceiling, stale refusal past ceiling, and metric counters (#784).
+
 ### Security
 
 - **Task #783 — Block local-auth fallback in production deployments**: When `NODE_ENV=production` and `ENTRA_AUTH_ENABLED=true`, `POST /api/auth/login` now returns `410 Gone` with `LOCAL_AUTH_DISABLED` error code unless `ENTRA_ALLOW_LOCAL_FALLBACK=true` is explicitly set. Startup emits a security warning when both Entra and local fallback are active in production. Integration tests in `backend/__tests__/auth-fallback.test.ts` cover all acceptance criteria (#783).

--- a/backend/__tests__/graph-groups.test.ts
+++ b/backend/__tests__/graph-groups.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  fetchGroupsWithCache,
+  getGraphGroupsMetrics,
+  getGraphGroupsCacheConfig,
+  GraphGroupsStaleError,
+  _resetGraphGroupsCacheForTest,
+} from '../src/services/graph-groups.js';
+
+describe('graph-groups cache service', () => {
+  beforeEach(() => {
+    _resetGraphGroupsCacheForTest();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    _resetGraphGroupsCacheForTest();
+    vi.unstubAllEnvs();
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path
+  // --------------------------------------------------------------------------
+
+  it('fetches groups on first call and returns them', async () => {
+    const groups = ['group-a', 'group-b'];
+    const fetcher = vi.fn().mockResolvedValue(groups);
+
+    const result = await fetchGroupsWithCache('oid-1', fetcher);
+
+    expect(result).toEqual(groups);
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_cache_miss_total).toBe(1);
+    expect(metrics.graph_groups_cache_hit_total).toBe(0);
+    expect(metrics.graph_groups_failure_total).toBe(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Cache hit
+  // --------------------------------------------------------------------------
+
+  it('returns cached groups on second call within TTL', async () => {
+    const groups = ['group-a'];
+    const fetcher = vi.fn().mockResolvedValue(groups);
+
+    await fetchGroupsWithCache('oid-1', fetcher);
+    const result = await fetchGroupsWithCache('oid-1', fetcher);
+
+    expect(result).toEqual(groups);
+    expect(fetcher).toHaveBeenCalledOnce(); // only first call
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_cache_hit_total).toBe(1);
+    expect(metrics.graph_groups_cache_miss_total).toBe(1);
+  });
+
+  it('caches independently per user OID', async () => {
+    const fetcherA = vi.fn().mockResolvedValue(['group-a']);
+    const fetcherB = vi.fn().mockResolvedValue(['group-b']);
+
+    const a = await fetchGroupsWithCache('oid-a', fetcherA);
+    const b = await fetchGroupsWithCache('oid-b', fetcherB);
+    const aCached = await fetchGroupsWithCache('oid-a', fetcherA);
+
+    expect(a).toEqual(['group-a']);
+    expect(b).toEqual(['group-b']);
+    expect(aCached).toEqual(['group-a']);
+    expect(fetcherA).toHaveBeenCalledOnce();
+    expect(fetcherB).toHaveBeenCalledOnce();
+  });
+
+  // --------------------------------------------------------------------------
+  // Graph error inside ceiling (stale fallback)
+  // --------------------------------------------------------------------------
+
+  it('serves stale cache when Graph fails within 24 h ceiling', async () => {
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1'); // 1 ms TTL so entry expires fast
+
+    const groups = ['group-a'];
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(groups)
+      .mockRejectedValueOnce(new Error('Graph 503'));
+
+    // First call succeeds — populates cache
+    await fetchGroupsWithCache('oid-1', fetcher);
+
+    // Wait for TTL to expire
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Second call fails — should serve stale data
+    const result = await fetchGroupsWithCache('oid-1', fetcher);
+
+    expect(result).toEqual(groups);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_failure_total).toBe(1);
+  });
+
+  // --------------------------------------------------------------------------
+  // Graph error past ceiling (503 refused)
+  // --------------------------------------------------------------------------
+
+  it('throws GraphGroupsStaleError when stale data exceeds 24 h ceiling', async () => {
+    // Set both TTL and max stale to 1 ms so both expire instantly
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1');
+    vi.stubEnv('GRAPH_GROUPS_MAX_STALE_MS', '1');
+
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(['group-a'])
+      .mockRejectedValueOnce(new Error('Graph 503'));
+
+    await fetchGroupsWithCache('oid-1', fetcher);
+
+    // Wait for both TTL and stale ceiling to expire
+    await new Promise((r) => setTimeout(r, 10));
+
+    await expect(fetchGroupsWithCache('oid-1', fetcher)).rejects.toThrow(GraphGroupsStaleError);
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_failure_total).toBe(1);
+  });
+
+  it('GraphGroupsStaleError has statusCode 503', () => {
+    const err = new GraphGroupsStaleError('oid-1', 100_000_000);
+    expect(err.statusCode).toBe(503);
+    expect(err.name).toBe('GraphGroupsStaleError');
+  });
+
+  // --------------------------------------------------------------------------
+  // Graph error with no prior cache entry
+  // --------------------------------------------------------------------------
+
+  it('re-throws when Graph fails and no cache entry exists', async () => {
+    const graphError = new Error('Graph timeout');
+    const fetcher = vi.fn().mockRejectedValue(graphError);
+
+    await expect(fetchGroupsWithCache('oid-new', fetcher)).rejects.toThrow('Graph timeout');
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_failure_total).toBe(1);
+  });
+
+  // --------------------------------------------------------------------------
+  // TTL refresh
+  // --------------------------------------------------------------------------
+
+  it('re-fetches after TTL expires and updates cache', async () => {
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1');
+
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(['group-old'])
+      .mockResolvedValueOnce(['group-new']);
+
+    await fetchGroupsWithCache('oid-1', fetcher);
+    await new Promise((r) => setTimeout(r, 5));
+    const result = await fetchGroupsWithCache('oid-1', fetcher);
+
+    expect(result).toEqual(['group-new']);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  // --------------------------------------------------------------------------
+  // Metrics reset
+  // --------------------------------------------------------------------------
+
+  it('_resetGraphGroupsCacheForTest resets cache and counters', async () => {
+    const fetcher = vi.fn().mockResolvedValue(['g']);
+    await fetchGroupsWithCache('oid-1', fetcher);
+    await fetchGroupsWithCache('oid-1', fetcher);
+
+    _resetGraphGroupsCacheForTest();
+
+    const metrics = getGraphGroupsMetrics();
+    expect(metrics.graph_groups_cache_hit_total).toBe(0);
+    expect(metrics.graph_groups_cache_miss_total).toBe(0);
+    expect(metrics.graph_groups_failure_total).toBe(0);
+
+    // Cache cleared — next call is a miss
+    const result = await fetchGroupsWithCache('oid-1', fetcher);
+    expect(result).toEqual(['g']);
+    expect(getGraphGroupsMetrics().graph_groups_cache_miss_total).toBe(1);
+  });
+
+  // --------------------------------------------------------------------------
+  // Default config values
+  // --------------------------------------------------------------------------
+
+  it('uses default TTL of 10 min and max stale of 24 h', () => {
+    // Clear any env overrides
+    delete process.env.GRAPH_GROUPS_CACHE_TTL_MS;
+    delete process.env.GRAPH_GROUPS_MAX_STALE_MS;
+
+    const config = getGraphGroupsCacheConfig();
+    expect(config.ttlMs).toBe(600_000);
+    expect(config.maxStaleMs).toBe(86_400_000);
+  });
+});

--- a/backend/__tests__/graph-groups.test.ts
+++ b/backend/__tests__/graph-groups.test.ts
@@ -12,9 +12,11 @@ describe('graph-groups cache service', () => {
   beforeEach(() => {
     _resetGraphGroupsCacheForTest();
     vi.unstubAllEnvs();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     _resetGraphGroupsCacheForTest();
     vi.unstubAllEnvs();
   });
@@ -77,7 +79,7 @@ describe('graph-groups cache service', () => {
   // --------------------------------------------------------------------------
 
   it('serves stale cache when Graph fails within 24 h ceiling', async () => {
-    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1'); // 1 ms TTL so entry expires fast
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '60000'); // 1 min TTL
 
     const groups = ['group-a'];
     const fetcher = vi.fn()
@@ -87,8 +89,8 @@ describe('graph-groups cache service', () => {
     // First call succeeds — populates cache
     await fetchGroupsWithCache('oid-1', fetcher);
 
-    // Wait for TTL to expire
-    await new Promise((r) => setTimeout(r, 5));
+    // Advance past TTL
+    vi.advanceTimersByTime(60_001);
 
     // Second call fails — should serve stale data
     const result = await fetchGroupsWithCache('oid-1', fetcher);
@@ -105,9 +107,8 @@ describe('graph-groups cache service', () => {
   // --------------------------------------------------------------------------
 
   it('throws GraphGroupsStaleError when stale data exceeds 24 h ceiling', async () => {
-    // Set both TTL and max stale to 1 ms so both expire instantly
-    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1');
-    vi.stubEnv('GRAPH_GROUPS_MAX_STALE_MS', '1');
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '60000');    // 1 min
+    vi.stubEnv('GRAPH_GROUPS_MAX_STALE_MS', '120000');   // 2 min ceiling
 
     const fetcher = vi.fn()
       .mockResolvedValueOnce(['group-a'])
@@ -115,8 +116,8 @@ describe('graph-groups cache service', () => {
 
     await fetchGroupsWithCache('oid-1', fetcher);
 
-    // Wait for both TTL and stale ceiling to expire
-    await new Promise((r) => setTimeout(r, 10));
+    // Advance past both TTL and stale ceiling
+    vi.advanceTimersByTime(120_001);
 
     await expect(fetchGroupsWithCache('oid-1', fetcher)).rejects.toThrow(GraphGroupsStaleError);
 
@@ -125,7 +126,7 @@ describe('graph-groups cache service', () => {
   });
 
   it('GraphGroupsStaleError has statusCode 503', () => {
-    const err = new GraphGroupsStaleError('oid-1', 100_000_000);
+    const err = new GraphGroupsStaleError('oid-1', 100_000_000, 86_400_000);
     expect(err.statusCode).toBe(503);
     expect(err.name).toBe('GraphGroupsStaleError');
   });
@@ -149,14 +150,14 @@ describe('graph-groups cache service', () => {
   // --------------------------------------------------------------------------
 
   it('re-fetches after TTL expires and updates cache', async () => {
-    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '1');
+    vi.stubEnv('GRAPH_GROUPS_CACHE_TTL_MS', '60000'); // 1 min
 
     const fetcher = vi.fn()
       .mockResolvedValueOnce(['group-old'])
       .mockResolvedValueOnce(['group-new']);
 
     await fetchGroupsWithCache('oid-1', fetcher);
-    await new Promise((r) => setTimeout(r, 5));
+    vi.advanceTimersByTime(60_001);
     const result = await fetchGroupsWithCache('oid-1', fetcher);
 
     expect(result).toEqual(['group-new']);

--- a/backend/src/controllers/entra-auth-controller.ts
+++ b/backend/src/controllers/entra-auth-controller.ts
@@ -11,6 +11,7 @@ import { validateEntraIdToken } from '../utils/entra-token.js';
 import { getDatabase } from '../db/database.js';
 import { generateTokens } from '../middleware/auth.js';
 import { hashToken, encryptToken, hashPassword } from '../utils/auth-helpers.js';
+import { fetchGroupsWithCache, GraphGroupsStaleError } from '../services/graph-groups.js';
 
 interface UserRow {
   id: number;
@@ -224,11 +225,20 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
 
   // FR-AUTH-003: When Entra token has group overage indicators, fetch groups via Graph.
   // This handles large group memberships where `groups` claim is omitted.
+  // #784 — uses cached graph-groups service with stale-data fallback.
   if (resolvedGroupIds.length === 0 && tokenHasGroupOverage(claims as unknown as Record<string, unknown>)) {
     if (accessTokenForGraph) {
+      const graphToken = accessTokenForGraph;
       try {
-        resolvedGroupIds = await fetchGroupIdsFromGraph(accessTokenForGraph);
+        resolvedGroupIds = await fetchGroupsWithCache(
+          entraOid,
+          () => fetchGroupIdsFromGraph(graphToken),
+        );
       } catch (error) {
+        if (error instanceof GraphGroupsStaleError) {
+          res.status(503).json({ error: 'Microsoft Graph is unavailable and cached data has expired. Please try again later.' });
+          return;
+        }
         console.warn('[Entra] Failed to resolve group overage via Graph; proceeding without group-derived role.', error);
       }
     } else {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -227,6 +227,25 @@ export function createApp(): express.Express {
     });
   });
 
+  // #784 — Graph groups cache metrics endpoint
+  app.get('/metrics', healthLimiter, async (_req, res) => {
+    const { getGraphGroupsMetrics } = await import('./services/graph-groups.js');
+    const m = getGraphGroupsMetrics();
+    const lines = [
+      `# HELP graph_groups_cache_hit_total Number of graph group cache hits`,
+      `# TYPE graph_groups_cache_hit_total counter`,
+      `graph_groups_cache_hit_total ${m.graph_groups_cache_hit_total}`,
+      `# HELP graph_groups_cache_miss_total Number of graph group cache misses`,
+      `# TYPE graph_groups_cache_miss_total counter`,
+      `graph_groups_cache_miss_total ${m.graph_groups_cache_miss_total}`,
+      `# HELP graph_groups_failure_total Number of graph group fetch failures`,
+      `# TYPE graph_groups_failure_total counter`,
+      `graph_groups_failure_total ${m.graph_groups_failure_total}`,
+    ];
+    res.setHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    res.send(lines.join('\n') + '\n');
+  });
+
   // CSRF token endpoint — called by the frontend before any state-changing request.
   // Returns an HMAC-signed token; no cookie required.
   // Uses a separate, higher limiter because the frontend may request a token

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,7 +21,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
 import { initializeDatabase } from './db/database.js';
 import { sanitizeRequestBody } from './middleware/sanitize-input.js';
-import { apiLimiter, csrfLimiter, healthLimiter } from './middleware/rate-limit.js';
+import { apiLimiter, csrfLimiter, healthLimiter, metricsLimiter } from './middleware/rate-limit.js';
 import { verifyEmailWebhookSignature } from './middleware/verify-email-webhook.js';
 import * as announcementController from './controllers/announcement-controller.js';
 import apiRoutes from './routes/api-routes.js';
@@ -228,7 +228,7 @@ export function createApp(): express.Express {
   });
 
   // #784 — Graph groups cache metrics endpoint
-  app.get('/metrics', healthLimiter, async (_req, res) => {
+  app.get('/metrics', metricsLimiter, async (_req, res) => {
     const { getGraphGroupsMetrics } = await import('./services/graph-groups.js');
     const m = getGraphGroupsMetrics();
     const lines = [

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -14,6 +14,16 @@ export const healthLimiter = rateLimit({
   message: { error: 'Too many health check requests.' },
 });
 
+// #784 — dedicated limiter for the /metrics endpoint; Prometheus scrapers may
+// poll more aggressively than health checkers.
+export const metricsLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many metrics requests.' },
+});
+
 // Per-IP limit for unauthenticated, user-facing public surfaces:
 // /public/events, /public/gallery, /public/rsvp, /public/unsubscribe.
 // These represent per-human actions (one guest opening one RSVP page), so

--- a/backend/src/services/graph-groups.ts
+++ b/backend/src/services/graph-groups.ts
@@ -34,10 +34,10 @@ export interface GraphGroupsMetrics {
 /** Thrown when the cache entry has exceeded the hard stale ceiling. */
 export class GraphGroupsStaleError extends Error {
   public readonly statusCode = 503;
-  constructor(oid: string, ageMs: number) {
+  constructor(oid: string, ageMs: number, ceilingMs: number) {
     super(
       `Graph groups for ${oid} are ${Math.round(ageMs / 60_000)} min stale ` +
-        `(exceeds 24 h ceiling). Refusing auth.`,
+        `(exceeds ${Math.round(ceilingMs / 3_600_000)} h ceiling). Refusing auth.`,
     );
     this.name = 'GraphGroupsStaleError';
   }
@@ -48,6 +48,7 @@ export class GraphGroupsStaleError extends Error {
 // ---------------------------------------------------------------------------
 
 const _cache = new Map<string, CacheEntry>();
+const MAX_CACHE_SIZE = 10_000;
 
 let _hitCount = 0;
 let _missCount = 0;
@@ -58,9 +59,14 @@ let _failureCount = 0;
 // ---------------------------------------------------------------------------
 
 export function getGraphGroupsCacheConfig(): GraphGroupsCacheConfig {
-  const ttlMs = parseInt(process.env.GRAPH_GROUPS_CACHE_TTL_MS ?? '600000', 10);
-  const maxStaleMs = parseInt(process.env.GRAPH_GROUPS_MAX_STALE_MS ?? '86400000', 10);
-  return { ttlMs, maxStaleMs };
+  const DEFAULT_TTL_MS = 600_000;
+  const DEFAULT_MAX_STALE_MS = 86_400_000;
+  const rawTtl = parseInt(process.env.GRAPH_GROUPS_CACHE_TTL_MS ?? '', 10);
+  const rawMaxStale = parseInt(process.env.GRAPH_GROUPS_MAX_STALE_MS ?? '', 10);
+  return {
+    ttlMs: Number.isFinite(rawTtl) && rawTtl >= 0 ? rawTtl : DEFAULT_TTL_MS,
+    maxStaleMs: Number.isFinite(rawMaxStale) && rawMaxStale >= 0 ? rawMaxStale : DEFAULT_MAX_STALE_MS,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +95,7 @@ export async function fetchGroupsWithCache(
   // Cache HIT — entry exists and is within TTL
   if (entry && now - entry.fetchedAt < ttlMs) {
     _hitCount++;
-    return entry.groupIds;
+    return entry.groupIds.slice();
   }
 
   // Cache MISS — attempt a fresh fetch
@@ -97,7 +103,8 @@ export async function fetchGroupsWithCache(
 
   try {
     const groupIds = await fetcher();
-    _cache.set(userOid, { groupIds, fetchedAt: now });
+    _cache.set(userOid, { groupIds: groupIds.slice(), fetchedAt: now });
+    _evictExpiredEntries(maxStaleMs, now);
     return groupIds;
   } catch (error) {
     _failureCount++;
@@ -111,10 +118,10 @@ export async function fetchGroupsWithCache(
             `(${Math.round(age / 60_000)} min old).`,
           error,
         );
-        return entry.groupIds;
+        return entry.groupIds.slice();
       }
       // Past the hard ceiling — refuse auth
-      throw new GraphGroupsStaleError(userOid, age);
+      throw new GraphGroupsStaleError(userOid, age, maxStaleMs);
     }
 
     // No cached data at all — cannot fall back
@@ -132,6 +139,28 @@ export function getGraphGroupsMetrics(): GraphGroupsMetrics {
     graph_groups_cache_miss_total: _missCount,
     graph_groups_failure_total: _failureCount,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Eviction
+// ---------------------------------------------------------------------------
+
+/** Remove entries older than maxStaleMs and enforce size cap. */
+function _evictExpiredEntries(maxStaleMs: number, now: number): void {
+  if (_cache.size <= MAX_CACHE_SIZE) return;
+  for (const [key, entry] of _cache) {
+    if (now - entry.fetchedAt > maxStaleMs) {
+      _cache.delete(key);
+    }
+  }
+  // If still over cap after purging expired, drop oldest entries
+  if (_cache.size > MAX_CACHE_SIZE) {
+    const entries = [..._cache.entries()].sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
+    const toRemove = entries.slice(0, _cache.size - MAX_CACHE_SIZE);
+    for (const [key] of toRemove) {
+      _cache.delete(key);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/graph-groups.ts
+++ b/backend/src/services/graph-groups.ts
@@ -1,0 +1,147 @@
+/**
+ * Microsoft Graph group-membership cache with failure-mode hardening.
+ *
+ * - In-memory cache keyed by user OID with configurable TTL (default 10 min).
+ * - On Graph failure, authorises with the last-known role up to a hard ceiling
+ *   of 24 hours stale; beyond that the login is refused with 503.
+ * - Exposes counter metrics via getGraphGroupsMetrics().
+ *
+ * @see https://github.com/seriously-not-prod/break-things-here/issues/784
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GraphGroupsCacheConfig {
+  /** Cache TTL in milliseconds (default 600 000 = 10 min). */
+  ttlMs: number;
+  /** Maximum stale age in milliseconds before refusing auth (default 86 400 000 = 24 h). */
+  maxStaleMs: number;
+}
+
+interface CacheEntry {
+  groupIds: string[];
+  fetchedAt: number;
+}
+
+export interface GraphGroupsMetrics {
+  graph_groups_cache_hit_total: number;
+  graph_groups_cache_miss_total: number;
+  graph_groups_failure_total: number;
+}
+
+/** Thrown when the cache entry has exceeded the hard stale ceiling. */
+export class GraphGroupsStaleError extends Error {
+  public readonly statusCode = 503;
+  constructor(oid: string, ageMs: number) {
+    super(
+      `Graph groups for ${oid} are ${Math.round(ageMs / 60_000)} min stale ` +
+        `(exceeds 24 h ceiling). Refusing auth.`,
+    );
+    this.name = 'GraphGroupsStaleError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+const _cache = new Map<string, CacheEntry>();
+
+let _hitCount = 0;
+let _missCount = 0;
+let _failureCount = 0;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export function getGraphGroupsCacheConfig(): GraphGroupsCacheConfig {
+  const ttlMs = parseInt(process.env.GRAPH_GROUPS_CACHE_TTL_MS ?? '600000', 10);
+  const maxStaleMs = parseInt(process.env.GRAPH_GROUPS_MAX_STALE_MS ?? '86400000', 10);
+  return { ttlMs, maxStaleMs };
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a user's Entra group IDs with caching and failure-mode hardening.
+ *
+ * @param userOid  - The Entra object ID of the authenticated user.
+ * @param fetcher  - Async function that hits Microsoft Graph and returns group IDs.
+ *                   Receives the user OID (not the access token) — the caller
+ *                   supplies a closure that already captures the access token.
+ * @returns The list of group IDs from cache or fresh fetch.
+ * @throws {GraphGroupsStaleError} when Graph is down AND the cached data has
+ *         exceeded the 24 h hard ceiling.
+ */
+export async function fetchGroupsWithCache(
+  userOid: string,
+  fetcher: () => Promise<string[]>,
+): Promise<string[]> {
+  const { ttlMs, maxStaleMs } = getGraphGroupsCacheConfig();
+  const now = Date.now();
+  const entry = _cache.get(userOid);
+
+  // Cache HIT — entry exists and is within TTL
+  if (entry && now - entry.fetchedAt < ttlMs) {
+    _hitCount++;
+    return entry.groupIds;
+  }
+
+  // Cache MISS — attempt a fresh fetch
+  _missCount++;
+
+  try {
+    const groupIds = await fetcher();
+    _cache.set(userOid, { groupIds, fetchedAt: now });
+    return groupIds;
+  } catch (error) {
+    _failureCount++;
+
+    // Stale fallback: serve the last-known value if within hard ceiling
+    if (entry) {
+      const age = now - entry.fetchedAt;
+      if (age <= maxStaleMs) {
+        console.warn(
+          `[GraphGroups] Graph fetch failed for ${userOid}; serving stale cache ` +
+            `(${Math.round(age / 60_000)} min old).`,
+          error,
+        );
+        return entry.groupIds;
+      }
+      // Past the hard ceiling — refuse auth
+      throw new GraphGroupsStaleError(userOid, age);
+    }
+
+    // No cached data at all — cannot fall back
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+export function getGraphGroupsMetrics(): GraphGroupsMetrics {
+  return {
+    graph_groups_cache_hit_total: _hitCount,
+    graph_groups_cache_miss_total: _missCount,
+    graph_groups_failure_total: _failureCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Reset all module-level state. Call in afterEach() in tests. */
+export function _resetGraphGroupsCacheForTest(): void {
+  _cache.clear();
+  _hitCount = 0;
+  _missCount = 0;
+  _failureCount = 0;
+}


### PR DESCRIPTION
## Summary
Implements Task #784 — adds an in-memory TTL cache for Microsoft Graph group lookups and hardened failure-mode handling.

## Changes
- **New**: `backend/src/services/graph-groups.ts` — in-memory cache keyed by `(user_oid)` with configurable TTL (default 10 min via `GRAPH_GROUPS_CACHE_TTL_MS`)
- **New**: `GET /metrics` endpoint exposing Prometheus counters: `graph_groups_cache_hit_total`, `graph_groups_cache_miss_total`, `graph_groups_failure_total`
- **Modified**: `backend/src/controllers/entra-auth-controller.ts` — group-overage fetches now route through the cache service with stale-data fallback
- **Modified**: `backend/src/index.ts` — added `/metrics` endpoint
- **New**: `backend/__tests__/graph-groups.test.ts` — 10 unit tests
- **Updated**: `CHANGELOG.md`

## Acceptance Criteria Coverage
- [x] In-memory cache keyed by `(user_oid)` with configurable TTL (default 10 min)
- [x] On Graph failure, authorise with last-known role up to 24 h stale; beyond that refuse with 503
- [x] Counter metrics exposed via existing metrics endpoint
- [x] Unit tests cover happy path, cache hit, Graph error inside ceiling, Graph error past ceiling
- [x] CHANGELOG entry

## Testing
- All 10 unit tests passing
- TypeScript type-check clean (no new errors)
- ESLint clean

Closes #784