### PR TITLE
feat(profile): add notification preferences tab to profile page #787

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (Track C — Auth & Identity)
+
+- **Task #787 — Notification preferences profile UI tab**: Added `frontend/src/components/profile/notification-preferences-tab.tsx` — a new Material-UI tab on the profile page that renders a category × channel matrix for notification preferences (In-App, Email, Push). Uses React Hook Form + Zod for form state, optimistic toggle saves via PUT endpoint with rollback on failure, and full keyboard/aria-label accessibility. Converted the profile page from a flat form to a tabbed layout (General Info + Notifications). Added 9 component tests in `frontend/test/notification-preferences-tab.test.tsx` covering initial load, toggle save, error rollback, accessibility, and table rendering (#787).
+
+- **Task #785 — End-to-end Entra login flow Playwright test (mocked OIDC)**: Added `e2e/entra-auth.spec.ts` with five tests that drive the full Microsoft sign-in → Azure redirect → callback → dashboard flow using Playwright route interception as a mocked OIDC issuer. Added `e2e/fixtures/oidc-mock.ts` providing reusable `setupOidcMock()` helper with pre-configured test users and well-known group IDs for role-mapping assertions (Admin, Organizer, Viewer, no-groups default). Added `.github/workflows/e2e.yml` CI workflow that builds the frontend, starts a preview server, installs Playwright Chromium, and runs the e2e suite. No live Azure tenant required (#785).
+
 ### Documentation
 
 - **Task #775 — PostgREST runtime decision and contract cleanup**: Removed the unused `postgrest` service from `docker-compose.yml`, recorded the "remove" decision and freed port `3001` in `docs/postgrest-pilot.md`, and updated TRD references in `docs/requirements/REQUIREMENTS_BASELINE.md` to declare Express `/api` as the active API contract (#775).

--- a/frontend/src/components/profile/notification-preferences-tab.tsx
+++ b/frontend/src/components/profile/notification-preferences-tab.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Checkbox,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import type { Resolver } from 'react-hook-form';
+import {
+  NOTIFICATION_TYPES,
+  listNotificationPreferences,
+  upsertNotificationPreference,
+  type NotificationPreference,
+  type NotificationType,
+} from '../../services/collaboration-service';
+
+const TYPE_LABELS: Record<NotificationType, string> = {
+  task_due: 'Task Due Soon',
+  task_overdue: 'Task Overdue',
+  task_assigned: 'Task Assigned to Me',
+  budget_alert: 'Budget Alert',
+  rsvp_submitted: 'RSVP Submitted',
+  event_update: 'Event Updated',
+  chat_message: 'Chat Message',
+  event_reminder: 'Event Reminder',
+};
+
+const CHANNELS = ['in_app_enabled', 'email_enabled', 'push_enabled'] as const;
+type Channel = (typeof CHANNELS)[number];
+
+const CHANNEL_LABELS: Record<Channel, string> = {
+  in_app_enabled: 'In-App',
+  email_enabled: 'Email',
+  push_enabled: 'Push',
+};
+
+const channelSchema = z.object({
+  in_app_enabled: z.boolean(),
+  email_enabled: z.boolean(),
+  push_enabled: z.boolean(),
+});
+
+const preferencesSchema = z.object(
+  Object.fromEntries(
+    NOTIFICATION_TYPES.map((type) => [type, channelSchema]),
+  ) as Record<NotificationType, typeof channelSchema>,
+);
+
+type PreferencesFormValues = z.infer<typeof preferencesSchema>;
+
+function buildDefaultValues(): PreferencesFormValues {
+  const values: Record<string, z.infer<typeof channelSchema>> = {};
+  for (const type of NOTIFICATION_TYPES) {
+    values[type] = { in_app_enabled: true, email_enabled: true, push_enabled: false };
+  }
+  return values as PreferencesFormValues;
+}
+
+function prefsToFormValues(
+  prefs: NotificationPreference[],
+): PreferencesFormValues {
+  const values = buildDefaultValues();
+  for (const p of prefs) {
+    if (p.notification_type in values) {
+      values[p.notification_type] = {
+        in_app_enabled: p.in_app_enabled,
+        email_enabled: p.email_enabled,
+        push_enabled: p.push_enabled,
+      };
+    }
+  }
+  return values;
+}
+
+export function NotificationPreferencesTab(): React.JSX.Element {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+
+  const { control, reset, getValues, setValue } = useForm<PreferencesFormValues>({
+    resolver: zodResolver(preferencesSchema) as Resolver<PreferencesFormValues>,
+    defaultValues: buildDefaultValues(),
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    listNotificationPreferences()
+      .then((list) => {
+        if (!cancelled) {
+          reset(prefsToFormValues(list));
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [reset]);
+
+  const handleToggle = useCallback(
+    async (type: NotificationType, channel: Channel) => {
+      const fieldPath = `${type}.${channel}` as const;
+      const currentValue = getValues(fieldPath as `${NotificationType}.${Channel}`);
+      const newValue = !currentValue;
+
+      // Optimistic update
+      setValue(fieldPath as `${NotificationType}.${Channel}`, newValue, { shouldDirty: true });
+      setError(null);
+      setSavingKey(`${type}.${channel}`);
+
+      try {
+        const typeValues = getValues(type);
+        await upsertNotificationPreference(type, {
+          email_enabled: typeValues.email_enabled,
+          in_app_enabled: typeValues.in_app_enabled,
+          push_enabled: typeValues.push_enabled,
+        });
+      } catch (err: unknown) {
+        // Rollback on failure
+        setValue(fieldPath as `${NotificationType}.${Channel}`, currentValue, { shouldDirty: true });
+        setError(err instanceof Error ? err.message : 'Failed to save preference');
+      } finally {
+        setSavingKey(null);
+      }
+    },
+    [getValues, setValue],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box aria-label="Notification preferences">
+      {error && (
+        <Alert
+          severity="error"
+          sx={{ mb: 2 }}
+          onClose={() => setError(null)}
+          role="alert"
+        >
+          {error}
+        </Alert>
+      )}
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small" aria-label="Notification preferences matrix">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Notification Type</TableCell>
+              {CHANNELS.map((ch) => (
+                <TableCell key={ch} align="center" sx={{ fontWeight: 600 }}>
+                  {CHANNEL_LABELS[ch]}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {NOTIFICATION_TYPES.map((type) => (
+              <TableRow key={type} hover>
+                <TableCell>{TYPE_LABELS[type]}</TableCell>
+                {CHANNELS.map((channel) => {
+                  const key = `${type}.${channel}`;
+                  const isSaving = savingKey === key;
+                  return (
+                    <TableCell key={channel} align="center" sx={{ py: 0.5 }}>
+                      {isSaving ? (
+                        <CircularProgress size={20} />
+                      ) : (
+                        <Controller
+                          name={`${type}.${channel}` as `${NotificationType}.${Channel}`}
+                          control={control}
+                          render={({ field }) => (
+                            <Checkbox
+                              checked={!!field.value}
+                              onChange={() => handleToggle(type, channel)}
+                              inputProps={{
+                                'aria-label': `${CHANNEL_LABELS[channel]} notifications for ${TYPE_LABELS[type]}`,
+                              }}
+                              size="small"
+                            />
+                          )}
+                        />
+                      )}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 1.5, display: 'block' }}>
+        Changes are saved immediately. Anti-spam batch rules are applied by the server.
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/profile/profile-page.tsx
+++ b/frontend/src/components/profile/profile-page.tsx
@@ -9,14 +9,17 @@ import {
   IconButton,
   Paper,
   Stack,
+  Tab,
+  Tabs,
   TextField,
   Tooltip,
   Typography,
 } from '@mui/material';
-import { CameraAltRounded, DeleteRounded, SaveRounded } from '@mui/icons-material';
+import { CameraAltRounded, DeleteRounded, NotificationsRounded, PersonRounded, SaveRounded } from '@mui/icons-material';
 import { api, apiFetch, ApiError } from '../../lib/api-client';
 import { useAuth } from '../../contexts/auth-context';
 import { PageLayout } from '../layout/page-layout';
+import { NotificationPreferencesTab } from './notification-preferences-tab';
 
 interface ProfileData {
   bio: string | null;
@@ -30,6 +33,7 @@ interface ProfileData {
 }
 export default function ProfilePage(): JSX.Element {
   const { user } = useAuth();
+  const [tab, setTab] = useState(0);
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [form, setForm] = useState({ bio: '', phone_number: '', address: '', city: '', state: '', zip_code: '', country: '' });
   const [displayName, setDisplayName] = useState('');
@@ -133,6 +137,35 @@ export default function ProfilePage(): JSX.Element {
       subtitle="Manage your account information and preferences"
       breadcrumbs={[{ label: 'Profile' }]}
     >
+      <Tabs
+        value={tab}
+        onChange={(_, v: number) => setTab(v)}
+        sx={{ mb: 2 }}
+        aria-label="Profile tabs"
+      >
+        <Tab
+          icon={<PersonRounded />}
+          iconPosition="start"
+          label="General Info"
+          id="profile-tab-0"
+          aria-controls="profile-tabpanel-0"
+        />
+        <Tab
+          icon={<NotificationsRounded />}
+          iconPosition="start"
+          label="Notifications"
+          id="profile-tab-1"
+          aria-controls="profile-tabpanel-1"
+        />
+      </Tabs>
+
+      <Box
+        role="tabpanel"
+        id="profile-tabpanel-0"
+        aria-labelledby="profile-tab-0"
+        hidden={tab !== 0}
+      >
+        {tab === 0 && (
       <Paper elevation={1} sx={{ p: 3, maxWidth: 680 }}>
         {/* Avatar */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2.5, mb: 3 }}>
@@ -203,6 +236,21 @@ export default function ProfilePage(): JSX.Element {
           </Stack>
         </Box>
       </Paper>
+        )}
+      </Box>
+
+      <Box
+        role="tabpanel"
+        id="profile-tabpanel-1"
+        aria-labelledby="profile-tab-1"
+        hidden={tab !== 1}
+      >
+        {tab === 1 && (
+          <Paper elevation={1} sx={{ p: 3, maxWidth: 680 }}>
+            <NotificationPreferencesTab />
+          </Paper>
+        )}
+      </Box>
     </PageLayout>
   );
 }

--- a/frontend/test/notification-preferences-tab.test.tsx
+++ b/frontend/test/notification-preferences-tab.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationPreferencesTab } from '../src/components/profile/notification-preferences-tab';
+import * as collaborationService from '../src/services/collaboration-service';
+import type { NotificationPreference } from '../src/services/collaboration-service';
+
+vi.mock('../src/services/collaboration-service', () => ({
+  NOTIFICATION_TYPES: [
+    'task_due',
+    'task_overdue',
+    'task_assigned',
+    'budget_alert',
+    'rsvp_submitted',
+    'event_update',
+    'chat_message',
+    'event_reminder',
+  ],
+  listNotificationPreferences: vi.fn(),
+  upsertNotificationPreference: vi.fn(),
+}));
+
+const mockedService = vi.mocked(collaborationService);
+
+const MOCK_PREFERENCES: NotificationPreference[] = [
+  { id: 1, user_id: 10, notification_type: 'task_due', email_enabled: true, in_app_enabled: true, push_enabled: false },
+  { id: 2, user_id: 10, notification_type: 'task_overdue', email_enabled: true, in_app_enabled: true, push_enabled: false },
+  { id: 3, user_id: 10, notification_type: 'task_assigned', email_enabled: true, in_app_enabled: true, push_enabled: true },
+  { id: 4, user_id: 10, notification_type: 'budget_alert', email_enabled: false, in_app_enabled: true, push_enabled: false },
+  { id: 5, user_id: 10, notification_type: 'rsvp_submitted', email_enabled: true, in_app_enabled: true, push_enabled: false },
+  { id: 6, user_id: 10, notification_type: 'event_update', email_enabled: true, in_app_enabled: true, push_enabled: false },
+  { id: 7, user_id: 10, notification_type: 'chat_message', email_enabled: true, in_app_enabled: true, push_enabled: false },
+  { id: 8, user_id: 10, notification_type: 'event_reminder', email_enabled: true, in_app_enabled: true, push_enabled: false },
+];
+
+describe('NotificationPreferencesTab', () => {
+  beforeEach(() => {
+    mockedService.listNotificationPreferences.mockResolvedValue(MOCK_PREFERENCES);
+    mockedService.upsertNotificationPreference.mockImplementation(
+      async (_type, prefs) =>
+        ({ id: 1, user_id: 10, notification_type: _type, ...prefs }) as NotificationPreference,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state initially', () => {
+    mockedService.listNotificationPreferences.mockReturnValue(new Promise(() => {}));
+    render(<NotificationPreferencesTab />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders the preferences matrix after loading', async () => {
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Task Due Soon')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Task Overdue')).toBeInTheDocument();
+    expect(screen.getByText('Task Assigned to Me')).toBeInTheDocument();
+    expect(screen.getByText('Budget Alert')).toBeInTheDocument();
+    expect(screen.getByText('RSVP Submitted')).toBeInTheDocument();
+    expect(screen.getByText('Event Updated')).toBeInTheDocument();
+    expect(screen.getByText('Chat Message')).toBeInTheDocument();
+    expect(screen.getByText('Event Reminder')).toBeInTheDocument();
+  });
+
+  it('renders column headers for all channels', async () => {
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('In-App')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Push')).toBeInTheDocument();
+  });
+
+  it('reflects initial preference values from the API', async () => {
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget Alert')).toBeInTheDocument();
+    });
+
+    const emailBudget = screen.getByLabelText('Email notifications for Budget Alert');
+    expect(emailBudget).not.toBeChecked();
+
+    const pushAssigned = screen.getByLabelText('Push notifications for Task Assigned to Me');
+    expect(pushAssigned).toBeChecked();
+  });
+
+  it('saves toggle change via API with optimistic update', async () => {
+    const user = userEvent.setup();
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget Alert')).toBeInTheDocument();
+    });
+
+    const emailBudget = screen.getByLabelText('Email notifications for Budget Alert');
+    expect(emailBudget).not.toBeChecked();
+
+    await user.click(emailBudget);
+
+    await waitFor(() => {
+      expect(mockedService.upsertNotificationPreference).toHaveBeenCalledWith(
+        'budget_alert',
+        expect.objectContaining({ email_enabled: true }),
+      );
+    });
+  });
+
+  it('rolls back on API failure', async () => {
+    const user = userEvent.setup();
+    mockedService.upsertNotificationPreference.mockRejectedValueOnce(
+      new Error('Network error'),
+    );
+
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget Alert')).toBeInTheDocument();
+    });
+
+    const emailBudget = screen.getByLabelText('Email notifications for Budget Alert');
+    expect(emailBudget).not.toBeChecked();
+
+    await user.click(emailBudget);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+    });
+
+    // Should be rolled back to unchecked
+    await waitFor(() => {
+      expect(screen.getByLabelText('Email notifications for Budget Alert')).not.toBeChecked();
+    });
+  });
+
+  it('displays error when loading preferences fails', async () => {
+    mockedService.listNotificationPreferences.mockRejectedValue(
+      new Error('Server unavailable'),
+    );
+
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Server unavailable');
+    });
+  });
+
+  it('has accessible aria-labels on all checkboxes', async () => {
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Task Due Soon')).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('In-App notifications for Task Due Soon')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email notifications for Task Due Soon')).toBeInTheDocument();
+    expect(screen.getByLabelText('Push notifications for Task Due Soon')).toBeInTheDocument();
+  });
+
+  it('renders the table with proper role for accessibility', async () => {
+    render(<NotificationPreferencesTab />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table', { name: 'Notification preferences matrix' })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements Task #787 — Notification preferences profile UI tab.

Surfaces the notification preferences backend endpoints to users via a new **Notifications** tab on the profile page.

## Changes

### New File
- `frontend/src/components/profile/notification-preferences-tab.tsx` — Material-UI category × channel matrix component with:
  - React Hook Form + Zod for form state management
  - Optimistic toggle saves via PUT `/api/notifications/preferences/:type` with rollback on failure
  - Full keyboard navigation and aria-labels per toggle
  - Loading/error states

### Modified File
- `frontend/src/components/profile/profile-page.tsx` — Converted from flat form to tabbed layout:
  - **General Info** tab (existing profile form)
  - **Notifications** tab (new notification preferences matrix)

### Test File
- `frontend/test/notification-preferences-tab.test.tsx` — 9 component tests covering:
  - Initial loading state
  - Matrix rendering with all notification types and channels
  - Column headers for In-App, Email, Push
  - Initial preference values from API
  - Optimistic toggle save via API
  - Rollback on API failure
  - Error display on load failure
  - Accessible aria-labels on all checkboxes
  - Table role for screen reader accessibility

## Acceptance Criteria Coverage
- [x] New "Notifications" tab on the profile page renders a category × channel matrix
- [x] Toggles save via PUT endpoint with optimistic updates and rollback on failure
- [x] Form uses React Hook Form + Zod
- [x] Keyboard-reachable; aria-labels per toggle
- [x] Component tests cover initial load, toggle, error rollback

## Validation
- ✅ TypeScript compilation — no errors
- ✅ ESLint — no new warnings/errors
- ✅ Vite production build — success
- ✅ Component tests — 9/9 passing
- ✅ Full test suite — no regressions (pre-existing failures unchanged)

Closes #787