### PR TITLE
fix(backend): add /api/health alias and health smoke coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Task #774 — SERIAL to UUID primary-key migration spike**: Added `docs/architecture/uuid-migration-spike.md` with migration option analysis (dual-column phased cutover vs in-place ALTER), data-migration script outline, FK rewrite plan, frontend type-change footprint, backward-compatibility risks, and effort estimates. Recorded decision in `docs/requirements/REQUIREMENTS_BASELINE.md` TRD section 4.2 to defer UUID cutover for the current cycle and ratify SERIAL/sequence-backed keys as the active baseline while tracking UUID migration as future phased work (#774).
 
+### Fixed
+
+- **Task #776 — Add `/api/health` TRD-compatible alias**: Backend now serves `GET /api/health` as an alias of `GET /health` using a shared handler so both endpoints always return identical payload and status. In-code OpenAPI definition now documents both routes, and smoke coverage in `backend/__tests__/health-endpoints.test.ts` asserts both endpoints return `200` and matching response bodies (#776).
+
 ### Added (Track E — Performance & Observability)
 
 - **Task #784 — Microsoft Graph group fetch — cache and failure-mode hardening**: Added `backend/src/services/graph-groups.ts` implementing an in-memory TTL cache keyed by user OID (default 10 min, configurable via `GRAPH_GROUPS_CACHE_TTL_MS`). On Graph API failure, requests are authorised using last-known cached role for up to 24 hours (`GRAPH_GROUPS_MAX_STALE_MS`); beyond that ceiling, login is refused with HTTP 503. Counter metrics `graph_groups_cache_hit_total`, `graph_groups_cache_miss_total`, `graph_groups_failure_total` exposed via `GET /metrics` in Prometheus text format. `backend/src/controllers/entra-auth-controller.ts` updated to route group-overage fetches through the cache. Unit tests in `backend/__tests__/graph-groups.test.ts` cover happy path, cache hit, stale fallback within ceiling, stale refusal past ceiling, and metric counters (#784).

--- a/backend/__tests__/health-endpoints.test.ts
+++ b/backend/__tests__/health-endpoints.test.ts
@@ -11,6 +11,7 @@ describe('health endpoint aliases (#776)', () => {
 
     expect(canonical.status).toBe(200);
     expect(alias.status).toBe(200);
+    expect(alias.headers['cache-control']).toBe(canonical.headers['cache-control']);
   });
 
   it('returns an identical payload shape from both endpoints', async () => {

--- a/backend/__tests__/health-endpoints.test.ts
+++ b/backend/__tests__/health-endpoints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../src/index.js';
+
+describe('health endpoint aliases (#776)', () => {
+  it('returns 200 for both /health and /api/health', async () => {
+    const app = createApp();
+
+    const canonical = await request(app).get('/health');
+    const alias = await request(app).get('/api/health');
+
+    expect(canonical.status).toBe(200);
+    expect(alias.status).toBe(200);
+  });
+
+  it('returns an identical payload shape from both endpoints', async () => {
+    const app = createApp();
+    const uptimeSpy = vi.spyOn(process, 'uptime').mockReturnValue(123.456);
+
+    try {
+      const canonical = await request(app).get('/health');
+      const alias = await request(app).get('/api/health');
+
+      expect(alias.body).toEqual(canonical.body);
+      expect(alias.body).toMatchObject({
+        status: expect.any(String),
+        uptime: expect.any(Number),
+        checks: expect.any(Object),
+      });
+    } finally {
+      uptimeSpy.mockRestore();
+    }
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -184,6 +184,12 @@ export function createApp(): express.Express {
   // - API GET/HEAD responses: 5-minute private cache
   // - vary on auth credentials to prevent cross-user cache bleed
   app.use('/api', (req, res, next) => {
+    // Keep /api/health behavior aligned with canonical /health endpoint.
+    if (req.path === '/health') {
+      next();
+      return;
+    }
+
     if (req.method === 'GET' || req.method === 'HEAD') {
       res.setHeader('Cache-Control', 'private, max-age=300, stale-while-revalidate=60');
       res.setHeader('Vary', 'Authorization, Cookie');
@@ -219,8 +225,11 @@ export function createApp(): express.Express {
       const { getPool } = await import('./db/database.js');
       const pool = getPool();
       const client = await pool.connect();
-      await client.query('SELECT 1');
-      client.release();
+      try {
+        await client.query('SELECT 1');
+      } finally {
+        client.release();
+      }
       checks.database = 'ok';
     } catch (err) {
       const msg = String(err);
@@ -326,6 +335,11 @@ export function createApp(): express.Express {
                 'Returns service health and database connectivity status. ' +
                 'Canonical health endpoint for runtime probes.',
               tags: ['Health'],
+              security: [],
+              servers: [
+                { url: `http://localhost:${port}`, description: 'Development (root)' },
+                { url: 'https://api.festivalplanner.example', description: 'Production (root)' },
+              ],
               responses: {
                 200: {
                   description: 'Service is healthy',
@@ -341,6 +355,11 @@ export function createApp(): express.Express {
               summary: 'Service health check (alias)',
               description: 'Alias of /health that returns the same payload and status code.',
               tags: ['Health'],
+              security: [],
+              servers: [
+                { url: `http://localhost:${port}`, description: 'Development (root)' },
+                { url: 'https://api.festivalplanner.example', description: 'Production (root)' },
+              ],
               responses: {
                 200: {
                   description: 'Service is healthy',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,9 @@
 import './config/load-env.js';
-import { isEntraEnabled, isLocalFallbackAllowed, validateEntraConfigAtStartup } from './config/entra.js';
+import {
+  isEntraEnabled,
+  isLocalFallbackAllowed,
+  validateEntraConfigAtStartup,
+} from './config/entra.js';
 import { assertStrictDataSecurityControlsAtStartup } from './config/security-controls.js';
 import { logger, requestLogger } from './utils/logger.js';
 import { startJobScheduler } from './utils/job-scheduler.js';
@@ -43,13 +47,15 @@ const CSRF_SECRET: string = (() => {
   if (s) return s;
   const env = process.env.NODE_ENV ?? 'development';
   if (env === 'production' || env === 'staging') {
-    console.error('[SECURITY] FATAL: CSRF_SECRET is not set in production/staging environment. Refusing to start.');
+    console.error(
+      '[SECURITY] FATAL: CSRF_SECRET is not set in production/staging environment. Refusing to start.',
+    );
     process.exit(1);
   }
   const ephemeral = crypto.randomBytes(32).toString('hex');
   console.warn(
     '[SECURITY] CSRF_SECRET is not set. Using an ephemeral per-startup secret — ' +
-    'tokens will not survive restarts. Set CSRF_SECRET for stable sessions.',
+      'tokens will not survive restarts. Set CSRF_SECRET for stable sessions.',
   );
   return ephemeral;
 })();
@@ -75,7 +81,10 @@ function isRequestSecure(req: express.Request): boolean {
   if (req.secure) return true;
   const forwardedProto = req.header('x-forwarded-proto');
   if (!forwardedProto) return false;
-  return forwardedProto.split(',').map((part) => part.trim()).includes('https');
+  return forwardedProto
+    .split(',')
+    .map((part) => part.trim())
+    .includes('https');
 }
 
 export function createApp(): express.Express {
@@ -151,7 +160,11 @@ export function createApp(): express.Express {
     }
   }
 
-  const csrfProtection = (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+  const csrfProtection = (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ): void => {
     // GET / HEAD / OPTIONS are safe methods — skip check
     if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
       next();
@@ -198,8 +211,8 @@ export function createApp(): express.Express {
     });
   }
 
-  // Health check — validates DB connectivity; returns 503 if DB unreachable (#676)
-  app.get('/health', healthLimiter, async (_req, res) => {
+  // Shared health handler so /health and /api/health always stay identical.
+  const healthCheckHandler: express.RequestHandler = async (_req, res) => {
     const checks: Record<string, string> = {};
     let httpStatus = 200;
     try {
@@ -225,7 +238,13 @@ export function createApp(): express.Express {
       uptime: process.uptime(),
       checks,
     });
-  });
+  };
+
+  // Health check — validates DB connectivity; returns 503 if DB unreachable (#676)
+  app.get('/health', healthLimiter, healthCheckHandler);
+
+  // TRD path compatibility alias.
+  app.get('/api/health', healthLimiter, healthCheckHandler);
 
   // #784 — Graph groups cache metrics endpoint
   app.get('/metrics', metricsLimiter, async (_req, res) => {
@@ -299,8 +318,47 @@ export function createApp(): express.Express {
           },
         },
         security: [{ BearerAuth: [] }],
+        paths: {
+          '/health': {
+            get: {
+              summary: 'Service health check',
+              description:
+                'Returns service health and database connectivity status. ' +
+                'Canonical health endpoint for runtime probes.',
+              tags: ['Health'],
+              responses: {
+                200: {
+                  description: 'Service is healthy',
+                },
+                503: {
+                  description: 'Service is degraded (for example, database unavailable)',
+                },
+              },
+            },
+          },
+          '/api/health': {
+            get: {
+              summary: 'Service health check (alias)',
+              description: 'Alias of /health that returns the same payload and status code.',
+              tags: ['Health'],
+              responses: {
+                200: {
+                  description: 'Service is healthy',
+                },
+                503: {
+                  description: 'Service is degraded (for example, database unavailable)',
+                },
+              },
+            },
+          },
+        },
       },
-      apis: ['./src/routes/*.ts', './src/routes/*.js', './src/controllers/*.ts', './src/controllers/*.js'],
+      apis: [
+        './src/routes/*.ts',
+        './src/routes/*.js',
+        './src/controllers/*.ts',
+        './src/controllers/*.js',
+      ],
     });
     app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, { explorer: true }));
     app.get('/api-docs.json', (_req, res) => res.json(swaggerSpec));
@@ -318,8 +376,8 @@ async function start(): Promise<void> {
   if (process.env.NODE_ENV === 'production' && isEntraEnabled() && isLocalFallbackAllowed()) {
     console.warn(
       '[SECURITY] WARNING: ENTRA_ALLOW_LOCAL_FALLBACK is enabled in production. ' +
-      'Local email/password login is available alongside Entra ID SSO. ' +
-      'Set ENTRA_ALLOW_LOCAL_FALLBACK=false (or unset it) to enforce Entra-only authentication.',
+        'Local email/password login is available alongside Entra ID SSO. ' +
+        'Set ENTRA_ALLOW_LOCAL_FALLBACK=false (or unset it) to enforce Entra-only authentication.',
     );
   }
 
@@ -331,7 +389,8 @@ async function start(): Promise<void> {
   });
 }
 
-const isDirectExecution = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isDirectExecution =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isDirectExecution) {
   start().catch((err) => {


### PR DESCRIPTION
## Summary
- add GET /api/health as an alias of GET /health via a shared handler
- document both health endpoints in the generated OpenAPI spec
- add smoke coverage to verify both endpoints return 200 and identical payload data
- add changelog entry for task 776

## Validation
- backend vitest run for health-endpoints and helmet-security-headers passed
- docker-compose healthcheck remains on /health

Refs #763
