### PR TITLE
feat(notifications): in-app notification centre (bell icon + list) #789

### DIFF
--- a/backend/src/controllers/notifications-controller.ts
+++ b/backend/src/controllers/notifications-controller.ts
@@ -3,12 +3,13 @@
  * BRD 3.11
  *
  * Route handlers (wired by integration owner):
- *   GET  /api/notifications               → listNotifications
- *   PATCH /api/notifications/:id          → markRead
- *   POST /api/notifications/mark-all-read → markAllRead
+ *   GET    /api/notifications               → listNotifications
+ *   PATCH  /api/notifications/:id           → markRead
+ *   DELETE /api/notifications/:id           → dismissNotification
+ *   POST   /api/notifications/mark-all-read → markAllRead
  *
  * Route added by this scope:
- *   GET /api/notifications/digest         → getDueTaskAlerts
+ *   GET /api/notifications/digest           → getDueTaskAlerts
  *
  * Internal helper functions (not routes — called by other controllers):
  *   createBudgetAlert
@@ -173,7 +174,7 @@ export async function createBudgetAlert(
     // Consult preference matrix before dispatching (#786)
     if (!(await isChannelEnabled(userId, 'in_app', 'budget_alert'))) return;
 
-    const db   = getDatabase();
+    const db = getDatabase();
     const link = `/events/${eventId}/budget`;
     await db.run(
       `INSERT INTO notifications (user_id, type, title, body, link)
@@ -204,7 +205,7 @@ export async function createRsvpNotification(
     // to align with the broader category naming convention in the preference matrix.
     if (!(await isChannelEnabled(userId, 'in_app', 'rsvp_submitted'))) return;
 
-    const db   = getDatabase();
+    const db = getDatabase();
     const link = `/events/${eventId}/guests`;
     await db.run(
       `INSERT INTO notifications (user_id, type, title, body, link)
@@ -279,11 +280,9 @@ export async function upsertNotificationPreference(req: AuthRequest, res: Respon
   }
   const { type } = req.params;
   if (!VALID_NOTIFICATION_TYPES.has(type)) {
-    res
-      .status(400)
-      .json({
-        error: `Invalid notification_type. Allowed: ${[...VALID_NOTIFICATION_TYPES].join(', ')}`,
-      });
+    res.status(400).json({
+      error: `Invalid notification_type. Allowed: ${[...VALID_NOTIFICATION_TYPES].join(', ')}`,
+    });
     return;
   }
   const { email_enabled, in_app_enabled, push_enabled } = req.body as {

--- a/backend/src/controllers/notifications-controller.ts
+++ b/backend/src/controllers/notifications-controller.ts
@@ -33,14 +33,20 @@ export async function listNotifications(req: AuthRequest, res: Response): Promis
     return;
   }
   const db = getDatabase();
+  const limit = Math.min(Math.max(Number(req.query.limit) || 20, 1), 50);
+  const offset = Math.max(Number(req.query.offset) || 0, 0);
   const rows = await db.all(
     `SELECT * FROM notifications
      WHERE user_id = $1
      ORDER BY created_at DESC
-     LIMIT 50`,
+     LIMIT $2 OFFSET $3`,
+    [req.user.id, limit, offset],
+  );
+  const total = await db.get<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM notifications WHERE user_id = $1`,
     [req.user.id],
   );
-  res.json({ notifications: rows });
+  res.json({ notifications: rows, total: total?.count ?? 0 });
 }
 
 /** PATCH /api/notifications/:id */
@@ -57,10 +63,10 @@ export async function markRead(req: AuthRequest, res: Response): Promise<void> {
     res.status(400).json({ error: 'Invalid notification id' });
     return;
   }
-  await db.run(
-    `UPDATE notifications SET is_read = TRUE WHERE id = $1 AND user_id = $2`,
-    [notifId, req.user.id],
-  );
+  await db.run(`UPDATE notifications SET is_read = TRUE WHERE id = $1 AND user_id = $2`, [
+    notifId,
+    req.user.id,
+  ]);
   res.json({ ok: true });
 }
 
@@ -71,10 +77,31 @@ export async function markAllRead(req: AuthRequest, res: Response): Promise<void
     return;
   }
   const db = getDatabase();
-  await db.run(
-    `UPDATE notifications SET is_read = TRUE WHERE user_id = $1`,
-    [req.user.id],
-  );
+  await db.run(`UPDATE notifications SET is_read = TRUE WHERE user_id = $1`, [req.user.id]);
+  res.json({ ok: true });
+}
+
+/** DELETE /api/notifications/:id */
+export async function dismissNotification(req: AuthRequest, res: Response): Promise<void> {
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const db = getDatabase();
+  const { id } = req.params;
+  const notifId = Number(id);
+  if (!Number.isInteger(notifId) || notifId <= 0) {
+    res.status(400).json({ error: 'Invalid notification id' });
+    return;
+  }
+  const result = await db.run(`DELETE FROM notifications WHERE id = $1 AND user_id = $2`, [
+    notifId,
+    req.user.id,
+  ]);
+  if (result.changes === 0) {
+    res.status(404).json({ error: 'Notification not found' });
+    return;
+  }
   res.json({ ok: true });
 }
 
@@ -88,16 +115,16 @@ export async function getDueTaskAlerts(req: AuthRequest, res: Response): Promise
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
-  const db     = getDatabase();
+  const db = getDatabase();
   const userId = req.user.id;
 
   const rows = await db.all<{
-    id:          number;
-    title:       string;
-    due_date:    string;
-    status:      string;
-    priority:    string;
-    event_id:    number;
+    id: number;
+    title: string;
+    due_date: string;
+    status: string;
+    priority: string;
+    event_id: number;
     event_title: string;
   }>(
     `SELECT t.id, t.title, t.due_date, t.status, t.priority, t.event_id,
@@ -151,11 +178,7 @@ export async function createBudgetAlert(
     await db.run(
       `INSERT INTO notifications (user_id, type, title, body, link)
        VALUES ($1, 'budget_alert', 'Budget Warning', $2, $3)`,
-      [
-        userId,
-        `Category "${categoryName}" is at ${pct}% of its allocation.`,
-        link,
-      ],
+      [userId, `Category "${categoryName}" is at ${pct}% of its allocation.`, link],
     );
   } catch (err) {
     console.error('createBudgetAlert failed:', err);
@@ -224,13 +247,22 @@ export async function createTaskDueAlert(
 // ── #623: Notification preferences ───────────────────────────────────────────
 
 const VALID_NOTIFICATION_TYPES = new Set([
-  'task_due', 'task_overdue', 'task_assigned', 'budget_alert',
-  'rsvp_submitted', 'event_update', 'chat_message', 'event_reminder',
+  'task_due',
+  'task_overdue',
+  'task_assigned',
+  'budget_alert',
+  'rsvp_submitted',
+  'event_update',
+  'chat_message',
+  'event_reminder',
 ]);
 
 /** GET /api/notifications/preferences */
 export async function listNotificationPreferences(req: AuthRequest, res: Response): Promise<void> {
-  if (!req.user) { res.status(401).json({ error: 'Unauthorized' }); return; }
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
   const db = getDatabase();
   const rows = await db.all(
     'SELECT * FROM notification_type_preferences WHERE user_id = $1 ORDER BY notification_type ASC',
@@ -241,10 +273,17 @@ export async function listNotificationPreferences(req: AuthRequest, res: Respons
 
 /** PUT /api/notifications/preferences/:type */
 export async function upsertNotificationPreference(req: AuthRequest, res: Response): Promise<void> {
-  if (!req.user) { res.status(401).json({ error: 'Unauthorized' }); return; }
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
   const { type } = req.params;
   if (!VALID_NOTIFICATION_TYPES.has(type)) {
-    res.status(400).json({ error: `Invalid notification_type. Allowed: ${[...VALID_NOTIFICATION_TYPES].join(', ')}` });
+    res
+      .status(400)
+      .json({
+        error: `Invalid notification_type. Allowed: ${[...VALID_NOTIFICATION_TYPES].join(', ')}`,
+      });
     return;
   }
   const { email_enabled, in_app_enabled, push_enabled } = req.body as {
@@ -275,9 +314,14 @@ export async function upsertNotificationPreference(req: AuthRequest, res: Respon
 
 /** GET /api/notifications/batch-rules */
 export async function listBatchRules(req: AuthRequest, res: Response): Promise<void> {
-  if (!req.user) { res.status(401).json({ error: 'Unauthorized' }); return; }
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
   const db = getDatabase();
-  const rules = await db.all('SELECT * FROM notification_batch_rules ORDER BY notification_type ASC');
+  const rules = await db.all(
+    'SELECT * FROM notification_batch_rules ORDER BY notification_type ASC',
+  );
   res.json({ rules });
 }
 

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -1021,6 +1021,7 @@ router.get(
 // ============ NOTIFICATIONS ROUTES — BRD 3.11 ============
 router.get('/notifications', authenticateToken, notificationsController.listNotifications);
 router.patch('/notifications/:id', authenticateToken, notificationsController.markRead);
+router.delete('/notifications/:id', authenticateToken, notificationsController.dismissNotification);
 router.post('/notifications/mark-all-read', authenticateToken, notificationsController.markAllRead);
 router.get('/notifications/digest', authenticateToken, notificationsController.getDueTaskAlerts);
 

--- a/frontend/src/components/nav/app-nav.tsx
+++ b/frontend/src/components/nav/app-nav.tsx
@@ -39,7 +39,7 @@ import {
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/auth-context';
 import { isAdmin } from '../../utils/roles';
-import { NotificationBell } from '../notifications/notification-bell';
+import { NotificationCenter } from './notification-center';
 import { useThemeMode } from '../../theme/theme-mode-context';
 import { LightModeRounded, DarkModeRounded } from '@mui/icons-material';
 import { useState, useCallback } from 'react';
@@ -68,7 +68,7 @@ interface NavItem {
 }
 
 function buildNavGroups(eventId: string | null, onNeedEvent: (sub: string) => void): NavGroup[] {
-  const ws = (sub: string): NavItem["to"] => eventId ? `/events/${eventId}/${sub}` : '/events';
+  const ws = (sub: string): NavItem['to'] => (eventId ? `/events/${eventId}/${sub}` : '/events');
   // Workspace items ALWAYS open the event picker so the user can choose
   // which event to view — never silently default to the last-used event.
   const wsItem = (label: string, sub: string, icon: JSX.Element): NavItem => ({
@@ -111,13 +111,7 @@ const ADMIN_NAV: NavItem[] = [
   { label: 'User Management', to: '/admin', icon: <ManageAccountsRounded />, adminOnly: true },
 ];
 
-function NavItemRow({
-  item,
-  collapsed,
-}: {
-  item: NavItem;
-  collapsed: boolean;
-}): JSX.Element {
+function NavItemRow({ item, collapsed }: { item: NavItem; collapsed: boolean }): JSX.Element {
   const location = useLocation();
   // For workspace items that use onClickOverride (no NavLink), detect active
   // state manually: match /events/<any-id>/<subPath>
@@ -173,18 +167,17 @@ function NavItemRow({
       {inner}
     </ListItemButton>
   ) : (
-    <ListItemButton
-      component={NavLink}
-      to={item.to}
-      end={item.end}
-      sx={sharedSx}
-    >
+    <ListItemButton component={NavLink} to={item.to} end={item.end} sx={sharedSx}>
       {inner}
     </ListItemButton>
   );
 
   if (collapsed) {
-    return <Tooltip title={item.label} placement="right">{btn}</Tooltip>;
+    return (
+      <Tooltip title={item.label} placement="right">
+        {btn}
+      </Tooltip>
+    );
   }
   return btn;
 }
@@ -207,8 +200,8 @@ function NavGroupSection({
     return true;
   });
 
-  const isGroupActive = visibleItems.some((item) =>
-    location.pathname === item.to || location.pathname.startsWith(item.to.split('?')[0])
+  const isGroupActive = visibleItems.some(
+    (item) => location.pathname === item.to || location.pathname.startsWith(item.to.split('?')[0]),
   );
 
   if (collapsed) {
@@ -257,7 +250,11 @@ function NavGroupSection({
             textTransform: 'uppercase',
           }}
         />
-        {open ? <ExpandLessRounded sx={{ fontSize: 16, color: 'rgba(255,255,255,0.4)' }} /> : <ExpandMoreRounded sx={{ fontSize: 16, color: 'rgba(255,255,255,0.4)' }} />}
+        {open ? (
+          <ExpandLessRounded sx={{ fontSize: 16, color: 'rgba(255,255,255,0.4)' }} />
+        ) : (
+          <ExpandMoreRounded sx={{ fontSize: 16, color: 'rgba(255,255,255,0.4)' }} />
+        )}
       </ListItemButton>
       <Collapse in={open} timeout="auto">
         <List dense disablePadding sx={{ pl: 0.5 }}>
@@ -323,36 +320,71 @@ export function AppNav({ collapsed, onToggleCollapse }: AppNavProps): React.Reac
 
   return (
     <>
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: drawerWidth,
-        flexShrink: 0,
-        transition: 'width 250ms cubic-bezier(0.4,0,0.2,1)',
-        '& .MuiDrawer-paper': {
-          width: drawerWidth,
-          overflowX: 'hidden',
-          transition: 'width 250ms cubic-bezier(0.4,0,0.2,1)',
-          boxSizing: 'border-box',
-          display: 'flex',
-          flexDirection: 'column',
-        },
-      }}
-    >
-      {/* ── Logo / Brand ── */}
-      <Box
+      <Drawer
+        variant="permanent"
         sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: collapsed ? 'center' : 'space-between',
-          px: collapsed ? 1 : 2,
-          py: 1.5,
-          minHeight: 60,
-          borderBottom: '1px solid rgba(255,255,255,0.07)',
+          width: drawerWidth,
+          flexShrink: 0,
+          transition: 'width 250ms cubic-bezier(0.4,0,0.2,1)',
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            overflowX: 'hidden',
+            transition: 'width 250ms cubic-bezier(0.4,0,0.2,1)',
+            boxSizing: 'border-box',
+            display: 'flex',
+            flexDirection: 'column',
+          },
         }}
       >
-        {!collapsed && (
-          <Stack direction="row" alignItems="center" spacing={1.25}>
+        {/* ── Logo / Brand ── */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: collapsed ? 'center' : 'space-between',
+            px: collapsed ? 1 : 2,
+            py: 1.5,
+            minHeight: 60,
+            borderBottom: '1px solid rgba(255,255,255,0.07)',
+          }}
+        >
+          {!collapsed && (
+            <Stack direction="row" alignItems="center" spacing={1.25}>
+              <Box
+                sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: '8px',
+                  background: 'linear-gradient(135deg, #2563EB 0%, #0ea5e9 100%)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                  fontSize: '0.75rem',
+                  fontWeight: 800,
+                  color: '#fff',
+                  letterSpacing: '-0.5px',
+                }}
+              >
+                EF
+              </Box>
+              <Box>
+                <Typography
+                  variant="subtitle1"
+                  sx={{ color: '#fff', fontWeight: 800, lineHeight: 1.1, fontSize: '0.9375rem' }}
+                >
+                  eQuip Fest
+                </Typography>
+                <Typography
+                  variant="caption"
+                  sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.625rem', lineHeight: 1 }}
+                >
+                  Festival Management
+                </Typography>
+              </Box>
+            </Stack>
+          )}
+          {collapsed && (
             <Box
               sx={{
                 width: 32,
@@ -362,217 +394,227 @@ export function AppNav({ collapsed, onToggleCollapse }: AppNavProps): React.Reac
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                flexShrink: 0,
                 fontSize: '0.75rem',
                 fontWeight: 800,
                 color: '#fff',
-                letterSpacing: '-0.5px',
               }}
             >
               EF
             </Box>
-            <Box>
-              <Typography
-                variant="subtitle1"
-                sx={{ color: '#fff', fontWeight: 800, lineHeight: 1.1, fontSize: '0.9375rem' }}
-              >
-                eQuip Fest
-              </Typography>
-              <Typography
-                variant="caption"
-                sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.625rem', lineHeight: 1 }}
-              >
-                Festival Management
-              </Typography>
-            </Box>
-          </Stack>
-        )}
-        {collapsed && (
-          <Box
-            sx={{
-              width: 32,
-              height: 32,
-              borderRadius: '8px',
-              background: 'linear-gradient(135deg, #2563EB 0%, #0ea5e9 100%)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '0.75rem',
-              fontWeight: 800,
-              color: '#fff',
-            }}
-          >
-            EF
-          </Box>
-        )}
-        {!collapsed && (
-          <IconButton
-            size="small"
-            onClick={onToggleCollapse}
-            sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' } }}
-            aria-label="Collapse sidebar"
-          >
-            <ChevronLeftRounded />
-          </IconButton>
-        )}
-      </Box>
-
-      {/* ── Expand button when collapsed ── */}
-      {collapsed && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1, borderBottom: '1px solid rgba(255,255,255,0.07)' }}>
-          <Tooltip title="Expand sidebar" placement="right">
+          )}
+          {!collapsed && (
             <IconButton
               size="small"
               onClick={onToggleCollapse}
-              sx={{ color: 'rgba(255,255,255,0.4)', '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' } }}
-              aria-label="Expand sidebar"
+              sx={{
+                color: 'rgba(255,255,255,0.4)',
+                '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' },
+              }}
+              aria-label="Collapse sidebar"
             >
-              <ChevronRightRounded />
+              <ChevronLeftRounded />
             </IconButton>
-          </Tooltip>
-        </Box>
-      )}
-
-      {/* ── Notification Bell ── */}
-      {!collapsed && (
-        <Box sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
-          <NotificationBell />
-        </Box>
-      )}
-      {collapsed && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 0.5 }}>
-          <NotificationBell />
-        </Box>
-      )}
-
-      {/* ── Scrollable Nav ── */}
-      <Box sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', py: 1 }}>
-        {/* Main items */}
-        <List dense disablePadding>
-          {mainItems.map((item) => (
-            <NavItemRow key={item.to} item={item} collapsed={collapsed} />
-          ))}
-        </List>
-
-        <Divider sx={{ my: 1, borderColor: 'rgba(255,255,255,0.07)' }} />
-
-        {/* Grouped nav sections */}
-        {!collapsed && navGroups.map((group, idx) => (
-          <NavGroupSection key={group.id} group={group} collapsed={false} defaultOpen={idx === 0} />
-        ))}
-        {collapsed && navGroups.map((group) => (
-          <NavGroupSection key={group.id} group={group} collapsed={true} />
-        ))}
-
-        {/* Admin */}
-        {adminItems.length > 0 && (
-          <>
-            <Divider sx={{ my: 1, borderColor: 'rgba(255,255,255,0.07)' }} />
-            <List dense disablePadding>
-              {adminItems.map((item) => (
-                <NavItemRow key={item.to} item={item} collapsed={collapsed} />
-              ))}
-            </List>
-          </>
-        )}
-      </Box>
-
-      {/* ── Bottom: theme toggle + user profile ── */}
-      <Divider sx={{ borderColor: 'rgba(255,255,255,0.07)' }} />
-      <Box sx={{ p: collapsed ? 1 : 1.5 }}>
-        {/* Dark mode toggle */}
-        <Box sx={{ display: 'flex', justifyContent: collapsed ? 'center' : 'flex-end', mb: 1 }}>
-          <Tooltip title={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'} placement="right">
-            <IconButton
-              size="small"
-              onClick={toggleMode}
-              sx={{ color: 'rgba(255,255,255,0.5)', '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' } }}
-              aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-            >
-              {mode === 'dark' ? <LightModeRounded fontSize="small" /> : <DarkModeRounded fontSize="small" />}
-            </IconButton>
-          </Tooltip>
+          )}
         </Box>
 
-        {/* User profile */}
-        <Tooltip title={collapsed ? (user?.displayName ?? user?.email ?? 'Profile') : ''} placement="right">
-          <ListItemButton
-            component={NavLink}
-            to="/profile"
+        {/* ── Expand button when collapsed ── */}
+        {collapsed && (
+          <Box
             sx={{
-              borderRadius: 8,
-              px: collapsed ? 1 : 1.25,
-              py: 0.75,
-              justifyContent: collapsed ? 'center' : 'flex-start',
-              color: 'rgba(255,255,255,0.7)',
-              '&:hover': { backgroundColor: 'rgba(255,255,255,0.07)', color: '#fff' },
-              '&.active': { backgroundColor: 'rgba(255,255,255,0.1)', color: '#fff' },
+              display: 'flex',
+              justifyContent: 'center',
+              py: 1,
+              borderBottom: '1px solid rgba(255,255,255,0.07)',
             }}
           >
-            <Avatar
+            <Tooltip title="Expand sidebar" placement="right">
+              <IconButton
+                size="small"
+                onClick={onToggleCollapse}
+                sx={{
+                  color: 'rgba(255,255,255,0.4)',
+                  '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' },
+                }}
+                aria-label="Expand sidebar"
+              >
+                <ChevronRightRounded />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
+
+        {/* ── Notification Centre ── */}
+        {!collapsed && (
+          <Box
+            sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}
+          >
+            <NotificationCenter />
+          </Box>
+        )}
+        {collapsed && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 0.5 }}>
+            <NotificationCenter />
+          </Box>
+        )}
+
+        {/* ── Scrollable Nav ── */}
+        <Box sx={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', py: 1 }}>
+          {/* Main items */}
+          <List dense disablePadding>
+            {mainItems.map((item) => (
+              <NavItemRow key={item.to} item={item} collapsed={collapsed} />
+            ))}
+          </List>
+
+          <Divider sx={{ my: 1, borderColor: 'rgba(255,255,255,0.07)' }} />
+
+          {/* Grouped nav sections */}
+          {!collapsed &&
+            navGroups.map((group, idx) => (
+              <NavGroupSection
+                key={group.id}
+                group={group}
+                collapsed={false}
+                defaultOpen={idx === 0}
+              />
+            ))}
+          {collapsed &&
+            navGroups.map((group) => (
+              <NavGroupSection key={group.id} group={group} collapsed={true} />
+            ))}
+
+          {/* Admin */}
+          {adminItems.length > 0 && (
+            <>
+              <Divider sx={{ my: 1, borderColor: 'rgba(255,255,255,0.07)' }} />
+              <List dense disablePadding>
+                {adminItems.map((item) => (
+                  <NavItemRow key={item.to} item={item} collapsed={collapsed} />
+                ))}
+              </List>
+            </>
+          )}
+        </Box>
+
+        {/* ── Bottom: theme toggle + user profile ── */}
+        <Divider sx={{ borderColor: 'rgba(255,255,255,0.07)' }} />
+        <Box sx={{ p: collapsed ? 1 : 1.5 }}>
+          {/* Dark mode toggle */}
+          <Box sx={{ display: 'flex', justifyContent: collapsed ? 'center' : 'flex-end', mb: 1 }}>
+            <Tooltip
+              title={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              placement="right"
+            >
+              <IconButton
+                size="small"
+                onClick={toggleMode}
+                sx={{
+                  color: 'rgba(255,255,255,0.5)',
+                  '&:hover': { color: '#fff', backgroundColor: 'rgba(255,255,255,0.08)' },
+                }}
+                aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {mode === 'dark' ? (
+                  <LightModeRounded fontSize="small" />
+                ) : (
+                  <DarkModeRounded fontSize="small" />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          {/* User profile */}
+          <Tooltip
+            title={collapsed ? (user?.displayName ?? user?.email ?? 'Profile') : ''}
+            placement="right"
+          >
+            <ListItemButton
+              component={NavLink}
+              to="/profile"
               sx={{
-                width: 30,
-                height: 30,
-                fontSize: '0.75rem',
-                fontWeight: 700,
-                bgcolor: '#2563EB',
-                flexShrink: 0,
-                mr: collapsed ? 0 : 1.25,
+                borderRadius: 8,
+                px: collapsed ? 1 : 1.25,
+                py: 0.75,
+                justifyContent: collapsed ? 'center' : 'flex-start',
+                color: 'rgba(255,255,255,0.7)',
+                '&:hover': { backgroundColor: 'rgba(255,255,255,0.07)', color: '#fff' },
+                '&.active': { backgroundColor: 'rgba(255,255,255,0.1)', color: '#fff' },
               }}
             >
-              {userInitials}
-            </Avatar>
-            {!collapsed && (
-              <Box sx={{ minWidth: 0 }}>
-                <Typography
-                  variant="body2"
-                  sx={{ color: '#fff', fontWeight: 600, fontSize: '0.8125rem', lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                >
-                  {user?.displayName ?? 'User'}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.6875rem', lineHeight: 1 }}
-                >
-                  {user?.roleName ?? 'Member'}
-                </Typography>
-              </Box>
-            )}
-          </ListItemButton>
-        </Tooltip>
+              <Avatar
+                sx={{
+                  width: 30,
+                  height: 30,
+                  fontSize: '0.75rem',
+                  fontWeight: 700,
+                  bgcolor: '#2563EB',
+                  flexShrink: 0,
+                  mr: collapsed ? 0 : 1.25,
+                }}
+              >
+                {userInitials}
+              </Avatar>
+              {!collapsed && (
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: '#fff',
+                      fontWeight: 600,
+                      fontSize: '0.8125rem',
+                      lineHeight: 1.2,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {user?.displayName ?? 'User'}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.6875rem', lineHeight: 1 }}
+                  >
+                    {user?.roleName ?? 'Member'}
+                  </Typography>
+                </Box>
+              )}
+            </ListItemButton>
+          </Tooltip>
 
-        {/* Logout */}
-        <Tooltip title="Log out" placement="right">
-          <ListItemButton
-            onClick={handleLogout}
-            sx={{
-              mt: 0.5,
-              borderRadius: 8,
-              px: collapsed ? 1 : 1.25,
-              py: 0.75,
-              justifyContent: collapsed ? 'center' : 'flex-start',
-              color: 'rgba(255,255,255,0.4)',
-              '&:hover': { backgroundColor: 'rgba(239,68,68,0.12)', color: '#f87171' },
-            }}
-            aria-label="Log out"
-          >
-            <ListItemIcon sx={{ color: 'inherit', minWidth: collapsed ? 0 : 36 }}>
-              <LogoutRounded fontSize="small" />
-            </ListItemIcon>
-            {!collapsed && (
-              <ListItemText primary="Log out" primaryTypographyProps={{ fontSize: '0.8125rem', fontWeight: 500 }} />
-            )}
-          </ListItemButton>
-        </Tooltip>
-      </Box>
-    </Drawer>
+          {/* Logout */}
+          <Tooltip title="Log out" placement="right">
+            <ListItemButton
+              onClick={handleLogout}
+              sx={{
+                mt: 0.5,
+                borderRadius: 8,
+                px: collapsed ? 1 : 1.25,
+                py: 0.75,
+                justifyContent: collapsed ? 'center' : 'flex-start',
+                color: 'rgba(255,255,255,0.4)',
+                '&:hover': { backgroundColor: 'rgba(239,68,68,0.12)', color: '#f87171' },
+              }}
+              aria-label="Log out"
+            >
+              <ListItemIcon sx={{ color: 'inherit', minWidth: collapsed ? 0 : 36 }}>
+                <LogoutRounded fontSize="small" />
+              </ListItemIcon>
+              {!collapsed && (
+                <ListItemText
+                  primary="Log out"
+                  primaryTypographyProps={{ fontSize: '0.8125rem', fontWeight: 500 }}
+                />
+              )}
+            </ListItemButton>
+          </Tooltip>
+        </Box>
+      </Drawer>
 
-    <EventPickerModal
-      open={pickerOpen}
-      targetSubPath={pendingSub}
-      onClose={() => setPickerOpen(false)}
-    />
+      <EventPickerModal
+        open={pickerOpen}
+        targetSubPath={pendingSub}
+        onClose={() => setPickerOpen(false)}
+      />
     </>
   );
 }
-

--- a/frontend/src/components/nav/notification-center.tsx
+++ b/frontend/src/components/nav/notification-center.tsx
@@ -4,6 +4,7 @@
  * Task #789
  */
 
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
@@ -25,9 +26,6 @@ import {
 } from '@mui/material';
 import NotificationsRounded from '@mui/icons-material/NotificationsRounded';
 import NotificationsNoneRounded from '@mui/icons-material/NotificationsNoneRounded';
-import TaskAltRounded from '@mui/icons-material/TaskAltRounded';
-import ReplyRounded from '@mui/icons-material/ReplyRounded';
-import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
 import CloseRounded from '@mui/icons-material/CloseRounded';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -37,26 +35,10 @@ import {
   dismissNotification,
   type Notification,
 } from '../../services/notifications-service';
+import { getIcon, formatTimeAgo } from '../notifications/notifications-panel';
 
 const POLL_INTERVAL_MS = 60_000;
 const PAGE_SIZE = 20;
-
-function getNotificationIcon(type: string): JSX.Element {
-  if (type === 'task_due') return <TaskAltRounded fontSize="small" />;
-  if (type === 'rsvp') return <ReplyRounded fontSize="small" />;
-  if (type === 'budget_alert') return <WarningAmberRounded fontSize="small" />;
-  return <NotificationsNoneRounded fontSize="small" />;
-}
-
-function formatTimeAgo(iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const minutes = Math.max(1, Math.floor(diffMs / 60_000));
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 export function NotificationCenter(): JSX.Element {
   const navigate = useNavigate();
@@ -223,7 +205,7 @@ export function NotificationCenter(): JSX.Element {
                       }}
                     >
                       <ListItemIcon sx={{ minWidth: 36, mt: 0.25 }}>
-                        {getNotificationIcon(notification.type)}
+                        {getIcon(notification.type)}
                       </ListItemIcon>
                       <ListItemText
                         primary={

--- a/frontend/src/components/nav/notification-center.tsx
+++ b/frontend/src/components/nav/notification-center.tsx
@@ -1,0 +1,282 @@
+/**
+ * Notification Centre
+ * Bell icon with unread badge + dropdown list with mark-read, dismiss, and pagination.
+ * Task #789
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Popover,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import NotificationsRounded from '@mui/icons-material/NotificationsRounded';
+import NotificationsNoneRounded from '@mui/icons-material/NotificationsNoneRounded';
+import TaskAltRounded from '@mui/icons-material/TaskAltRounded';
+import ReplyRounded from '@mui/icons-material/ReplyRounded';
+import WarningAmberRounded from '@mui/icons-material/WarningAmberRounded';
+import CloseRounded from '@mui/icons-material/CloseRounded';
+import { useNavigate } from 'react-router-dom';
+import {
+  listNotifications,
+  markAllRead,
+  markRead,
+  dismissNotification,
+  type Notification,
+} from '../../services/notifications-service';
+
+const POLL_INTERVAL_MS = 60_000;
+const PAGE_SIZE = 20;
+
+function getNotificationIcon(type: string): JSX.Element {
+  if (type === 'task_due') return <TaskAltRounded fontSize="small" />;
+  if (type === 'rsvp') return <ReplyRounded fontSize="small" />;
+  if (type === 'budget_alert') return <WarningAmberRounded fontSize="small" />;
+  return <NotificationsNoneRounded fontSize="small" />;
+}
+
+function formatTimeAgo(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minutes = Math.max(1, Math.floor(diffMs / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function NotificationCenter(): JSX.Element {
+  const navigate = useNavigate();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const open = Boolean(anchorEl);
+
+  const fetchPage = useCallback(async (offset: number, append: boolean): Promise<void> => {
+    try {
+      if (!append) setError(null);
+      const result = await listNotifications(PAGE_SIZE, offset);
+      const items = result.notifications ?? [];
+      setTotal(result.total ?? 0);
+      setNotifications((prev) => (append ? [...prev, ...items] : items));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load notifications.');
+    }
+  }, []);
+
+  const loadInitial = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    await fetchPage(0, false);
+    setLoading(false);
+  }, [fetchPage]);
+
+  useEffect(() => {
+    void loadInitial();
+    pollRef.current = setInterval(() => void loadInitial(), POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [loadInitial]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => !n.is_read).length,
+    [notifications],
+  );
+
+  const hasMore = notifications.length < total;
+
+  async function handleLoadMore(): Promise<void> {
+    setLoadingMore(true);
+    await fetchPage(notifications.length, true);
+    setLoadingMore(false);
+  }
+
+  async function handleMarkRead(notification: Notification): Promise<void> {
+    if (notification.is_read) return;
+    await markRead(notification.id);
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === notification.id ? { ...n, is_read: true } : n)),
+    );
+  }
+
+  async function handleMarkAllRead(): Promise<void> {
+    await markAllRead();
+    setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
+  }
+
+  async function handleDismiss(event: React.MouseEvent, notification: Notification): Promise<void> {
+    event.stopPropagation();
+    await dismissNotification(notification.id);
+    setNotifications((prev) => prev.filter((n) => n.id !== notification.id));
+    setTotal((prev) => Math.max(0, prev - 1));
+  }
+
+  async function handleClick(notification: Notification): Promise<void> {
+    await handleMarkRead(notification);
+    setAnchorEl(null);
+    if (notification.link) {
+      navigate(notification.link);
+    }
+  }
+
+  return (
+    <>
+      <Tooltip title="Notifications">
+        <IconButton
+          color="inherit"
+          aria-label={`Notifications, ${unreadCount} unread`}
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+        >
+          <Badge badgeContent={unreadCount} color="error">
+            <NotificationsRounded />
+          </Badge>
+        </IconButton>
+      </Tooltip>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: { sx: { width: 380, maxWidth: 'calc(100vw - 24px)', mt: 1 } },
+        }}
+      >
+        <Stack spacing={0}>
+          {/* Header */}
+          <Box sx={{ p: 2, pb: 1.5 }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Box>
+                <Typography variant="h6" fontWeight={800}>
+                  Notifications
+                </Typography>
+                <Typography variant="caption" color="text.secondary" aria-live="polite">
+                  {unreadCount} unread
+                </Typography>
+              </Box>
+              <Button
+                size="small"
+                onClick={() => void handleMarkAllRead()}
+                disabled={unreadCount === 0}
+              >
+                Mark all read
+              </Button>
+            </Stack>
+          </Box>
+          <Divider />
+
+          {/* Body */}
+          {loading ? (
+            <Stack spacing={1} sx={{ p: 2 }}>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} variant="rounded" height={64} />
+              ))}
+            </Stack>
+          ) : error ? (
+            <Box sx={{ p: 2 }}>
+              <Alert severity="error">{error}</Alert>
+            </Box>
+          ) : notifications.length === 0 ? (
+            <Stack
+              spacing={1}
+              alignItems="center"
+              justifyContent="center"
+              sx={{ p: 4, textAlign: 'center' }}
+            >
+              <NotificationsNoneRounded color="disabled" />
+              <Typography fontWeight={700}>You&apos;re all caught up</Typography>
+              <Typography variant="body2" color="text.secondary">
+                New RSVPs, budget warnings, and due tasks will show up here.
+              </Typography>
+            </Stack>
+          ) : (
+            <>
+              <List disablePadding sx={{ maxHeight: 420, overflowY: 'auto' }}>
+                {notifications.map((notification, idx) => (
+                  <Box key={notification.id}>
+                    <ListItemButton
+                      alignItems="flex-start"
+                      onClick={() => void handleClick(notification)}
+                      sx={{
+                        px: 2,
+                        py: 1.5,
+                        bgcolor: notification.is_read ? 'transparent' : 'action.hover',
+                      }}
+                    >
+                      <ListItemIcon sx={{ minWidth: 36, mt: 0.25 }}>
+                        {getNotificationIcon(notification.type)}
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          <Stack direction="row" justifyContent="space-between" spacing={1}>
+                            <Typography
+                              variant="body2"
+                              fontWeight={notification.is_read ? 600 : 800}
+                            >
+                              {notification.title}
+                            </Typography>
+                            <Typography variant="caption" color="text.secondary" noWrap>
+                              {formatTimeAgo(notification.created_at)}
+                            </Typography>
+                          </Stack>
+                        }
+                        secondary={
+                          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                            {notification.body ?? ''}
+                          </Typography>
+                        }
+                      />
+                      <Tooltip title="Dismiss">
+                        <IconButton
+                          size="small"
+                          edge="end"
+                          aria-label={`Dismiss ${notification.title}`}
+                          onClick={(e) => void handleDismiss(e, notification)}
+                          sx={{ ml: 0.5, mt: 0.25, flexShrink: 0 }}
+                        >
+                          <CloseRounded fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </ListItemButton>
+                    {idx < notifications.length - 1 && <Divider component="li" />}
+                  </Box>
+                ))}
+              </List>
+              {hasMore && (
+                <Box sx={{ p: 1.5, textAlign: 'center' }}>
+                  <Button
+                    size="small"
+                    onClick={() => void handleLoadMore()}
+                    disabled={loadingMore}
+                    startIcon={loadingMore ? <CircularProgress size={14} /> : undefined}
+                  >
+                    {loadingMore ? 'Loading\u2026' : 'Load more'}
+                  </Button>
+                </Box>
+              )}
+            </>
+          )}
+        </Stack>
+      </Popover>
+    </>
+  );
+}

--- a/frontend/src/components/notifications/notification-bell.tsx
+++ b/frontend/src/components/notifications/notification-bell.tsx
@@ -26,7 +26,7 @@ export function NotificationBell(): JSX.Element {
     try {
       setError(null);
       const result = await listNotifications();
-      setNotifications(result);
+      setNotifications(result.notifications ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load notifications.');
     } finally {
@@ -62,9 +62,7 @@ export function NotificationBell(): JSX.Element {
     if (!notification.is_read) {
       await markRead(notification.id);
       setNotifications((current) =>
-        current.map((item) =>
-          item.id === notification.id ? { ...item, is_read: true } : item,
-        ),
+        current.map((item) => (item.id === notification.id ? { ...item, is_read: true } : item)),
       );
     }
   }

--- a/frontend/src/components/notifications/notifications-panel.tsx
+++ b/frontend/src/components/notifications/notifications-panel.tsx
@@ -36,14 +36,14 @@ interface NotificationsPanelProps {
   onMarkAllRead: () => Promise<void>;
 }
 
-function getIcon(type: string): JSX.Element {
+export function getIcon(type: string): JSX.Element {
   if (type === 'task_due') return <TaskAltRounded fontSize="small" />;
   if (type === 'rsvp') return <ReplyRounded fontSize="small" />;
   if (type === 'budget_alert') return <WarningAmberRounded fontSize="small" />;
   return <NotificationsNoneRounded fontSize="small" />;
 }
 
-function formatTimeAgo(iso: string): string {
+export function formatTimeAgo(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
   const minutes = Math.max(1, Math.floor(diffMs / 60000));
   if (minutes < 60) return `${minutes}m ago`;
@@ -115,7 +115,12 @@ export function NotificationsPanel({
             <Alert severity="error">{error}</Alert>
           </Box>
         ) : notifications.length === 0 ? (
-          <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ p: 4, textAlign: 'center' }}>
+          <Stack
+            spacing={1}
+            alignItems="center"
+            justifyContent="center"
+            sx={{ p: 4, textAlign: 'center' }}
+          >
             <NotificationsNoneRounded color="disabled" />
             <Typography fontWeight={700}>You're all caught up</Typography>
             <Typography variant="body2" color="text.secondary">

--- a/frontend/src/services/notifications-service.ts
+++ b/frontend/src/services/notifications-service.ts
@@ -9,23 +9,28 @@ import { api } from '../lib/api-client';
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface Notification {
-  id:         number;
-  user_id:    number;
-  type:       'budget_alert' | 'rsvp' | 'task_due' | string;
-  title:      string;
-  body:       string | null;
-  link:       string | null;
-  is_read:    boolean;
+  id: number;
+  user_id: number;
+  type: 'budget_alert' | 'rsvp' | 'task_due' | string;
+  title: string;
+  body: string | null;
+  link: string | null;
+  is_read: boolean;
   created_at: string;
 }
 
+export interface PaginatedNotifications {
+  notifications: Notification[];
+  total: number;
+}
+
 export interface NotificationDigestTask {
-  id:          number;
-  title:       string;
-  due_date:    string;
-  status:      string;
-  priority:    string;
-  event_id:    number;
+  id: number;
+  title: string;
+  due_date: string;
+  status: string;
+  priority: string;
+  event_id: number;
   event_title: string;
 }
 
@@ -38,9 +43,8 @@ export interface NotificationDigest {
 /**
  * Fetches the most recent notifications for the authenticated user.
  */
-export async function listNotifications(): Promise<Notification[]> {
-  const res = await api.get<{ notifications: Notification[] }>('/api/notifications');
-  return res.notifications ?? [];
+export async function listNotifications(limit = 20, offset = 0): Promise<PaginatedNotifications> {
+  return api.get<PaginatedNotifications>(`/api/notifications?limit=${limit}&offset=${offset}`);
 }
 
 /**
@@ -55,6 +59,13 @@ export async function markRead(id: number): Promise<void> {
  */
 export async function markAllRead(): Promise<void> {
   await api.post<{ ok: boolean }>('/api/notifications/mark-all-read', {});
+}
+
+/**
+ * Dismisses (deletes) a single notification.
+ */
+export async function dismissNotification(id: number): Promise<void> {
+  await api.delete<{ ok: boolean }>(`/api/notifications/${id}`);
 }
 
 /**

--- a/frontend/test/notification-center.test.tsx
+++ b/frontend/test/notification-center.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for NotificationCenter component
+ * Task #789
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NotificationCenter } from '../src/components/nav/notification-center';
+import * as notificationsService from '../src/services/notifications-service';
+import type { Notification } from '../src/services/notifications-service';
+
+vi.mock('../src/services/notifications-service', () => ({
+  listNotifications: vi.fn(),
+  markRead: vi.fn(),
+  markAllRead: vi.fn(),
+  dismissNotification: vi.fn(),
+}));
+
+const service = vi.mocked(notificationsService);
+
+function mkNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 1,
+    user_id: 10,
+    type: 'task_due',
+    title: 'Task is due',
+    body: 'Some body text',
+    link: '/events/1',
+    is_read: false,
+    created_at: new Date(Date.now() - 300_000).toISOString(),
+    ...overrides,
+  };
+}
+
+const ITEMS: Notification[] = [
+  mkNotification({ id: 1, title: 'First', is_read: false }),
+  mkNotification({ id: 2, title: 'Second', is_read: true }),
+  mkNotification({ id: 3, title: 'Third', is_read: false }),
+];
+
+function renderCenter(): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter>
+      <NotificationCenter />
+    </MemoryRouter>,
+  );
+}
+
+describe('NotificationCenter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    service.listNotifications.mockResolvedValue({ notifications: ITEMS, total: ITEMS.length });
+    service.markRead.mockResolvedValue(undefined);
+    service.markAllRead.mockResolvedValue(undefined);
+    service.dismissNotification.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders bell icon with unread badge', async () => {
+    renderCenter();
+    const btn = await screen.findByRole('button', { name: /notifications/i });
+    expect(btn).toBeDefined();
+  });
+
+  it('opens dropdown when bell is clicked', async () => {
+    renderCenter();
+    const btn = await screen.findByRole('button', { name: /notifications/i });
+    fireEvent.click(btn);
+    expect(await screen.findByText('Notifications')).toBeDefined();
+  });
+
+  it('displays notification titles in dropdown', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    expect(await screen.findByText('First')).toBeDefined();
+    expect(screen.getByText('Second')).toBeDefined();
+    expect(screen.getByText('Third')).toBeDefined();
+  });
+
+  it('shows unread count', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    expect(await screen.findByText('2 unread')).toBeDefined();
+  });
+
+  it('shows empty state when no notifications', async () => {
+    service.listNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    expect(await screen.findByText(/all caught up/i)).toBeDefined();
+  });
+
+  it('shows loading skeletons initially', () => {
+    service.listNotifications.mockReturnValue(new Promise(() => {}));
+    renderCenter();
+    fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    expect(screen.queryByText('First')).toBeNull();
+  });
+
+  it('shows error state', async () => {
+    service.listNotifications.mockRejectedValue(new Error('Server error'));
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    expect(await screen.findByText('Server error')).toBeDefined();
+  });
+
+  it('calls markRead when clicking a notification', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    fireEvent.click(await screen.findByText('First'));
+    await waitFor(() => expect(service.markRead).toHaveBeenCalledWith(1));
+  });
+
+  it('calls markAllRead', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    fireEvent.click(await screen.findByText('Mark all read'));
+    await waitFor(() => expect(service.markAllRead).toHaveBeenCalled());
+  });
+
+  it('disables mark-all-read when no unread', async () => {
+    const allRead = ITEMS.map((n) => ({ ...n, is_read: true }));
+    service.listNotifications.mockResolvedValue({ notifications: allRead, total: allRead.length });
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    const markAllBtn = await screen.findByText('Mark all read');
+    expect(markAllBtn.closest('button')?.disabled).toBe(true);
+  });
+
+  it('calls dismissNotification when dismiss button clicked', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    const dismissBtn = await screen.findByRole('button', { name: /dismiss first/i });
+    fireEvent.click(dismissBtn);
+    await waitFor(() => expect(service.dismissNotification).toHaveBeenCalledWith(1));
+  });
+
+  it('shows Load more when there are more items', async () => {
+    service.listNotifications.mockResolvedValue({ notifications: ITEMS.slice(0, 2), total: 5 });
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    expect(await screen.findByText('Load more')).toBeDefined();
+  });
+
+  it('hides Load more when all loaded', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    await screen.findByText('First');
+    expect(screen.queryByText('Load more')).toBeNull();
+  });
+
+  it('polls for notifications on interval', async () => {
+    renderCenter();
+    await waitFor(() => expect(service.listNotifications).toHaveBeenCalled());
+    const callsBefore = service.listNotifications.mock.calls.length;
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await waitFor(() =>
+      expect(service.listNotifications.mock.calls.length).toBeGreaterThan(callsBefore),
+    );
+  });
+
+  it('shows aria-live region with unread count', async () => {
+    renderCenter();
+    fireEvent.click(await screen.findByRole('button', { name: /notifications/i }));
+    const live = await screen.findByText('2 unread');
+    expect(live.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/frontend/test/notifications.test.tsx
+++ b/frontend/test/notifications.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../src/services/notifications-service', () => ({
   listNotifications: vi.fn(),
   markRead: vi.fn(),
   markAllRead: vi.fn(),
+  dismissNotification: vi.fn(),
   getDueTaskAlerts: vi.fn(),
 }));
 
@@ -105,9 +106,7 @@ describe('NotificationsPanel', () => {
   it('renders notification bodies', () => {
     renderPanel();
     expect(screen.getByText('Alice confirmed attendance.')).toBeInTheDocument();
-    expect(
-      screen.getByText(/Category "Catering" is at 92%/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Category "Catering" is at 92%/i)).toBeInTheDocument();
   });
 
   it('shows loading skeletons when loading is true', () => {
@@ -147,9 +146,7 @@ describe('NotificationsPanel', () => {
 
     await user.click(screen.getByText('New RSVP'));
     await waitFor(() => {
-      expect(onMarkRead).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 1 }),
-      );
+      expect(onMarkRead).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
     });
   });
 
@@ -180,9 +177,7 @@ describe('NotificationsPanel', () => {
   it('"Mark all read" button is disabled when all are read', () => {
     const allRead = MOCK_NOTIFICATIONS.map((n) => ({ ...n, is_read: true }));
     renderPanel(allRead);
-    expect(
-      screen.getByRole('button', { name: /mark all read/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: /mark all read/i })).toBeDisabled();
   });
 
   it('has aria-live region for unread count (accessible updates)', () => {
@@ -194,7 +189,10 @@ describe('NotificationsPanel', () => {
 
 describe('NotificationBell', () => {
   beforeEach(() => {
-    mockedService.listNotifications.mockResolvedValue(MOCK_NOTIFICATIONS);
+    mockedService.listNotifications.mockResolvedValue({
+      notifications: MOCK_NOTIFICATIONS,
+      total: MOCK_NOTIFICATIONS.length,
+    });
     mockedService.markAllRead.mockResolvedValue(undefined);
     mockedService.markRead.mockResolvedValue(undefined);
   });
@@ -215,9 +213,7 @@ describe('NotificationBell', () => {
   it('renders the bell icon button', async () => {
     renderBell();
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /notifications/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
     });
   });
 
@@ -243,7 +239,10 @@ describe('NotificationBell', () => {
 
   it('polls listNotifications every 60 seconds', async () => {
     vi.useFakeTimers();
-    mockedService.listNotifications.mockResolvedValue(MOCK_NOTIFICATIONS);
+    mockedService.listNotifications.mockResolvedValue({
+      notifications: MOCK_NOTIFICATIONS,
+      total: MOCK_NOTIFICATIONS.length,
+    });
 
     renderBell();
 


### PR DESCRIPTION
## Summary
Implements Task #789 – In-app notification centre with bell icon and dropdown list.

## Changes
- **NotificationCenter component** – Bell icon with unread badge, popover dropdown with notification list, mark-read, mark-all-read, dismiss, pagination (load more), empty/loading/error states, aria-live accessibility
- **Backend dismiss endpoint** – `DELETE /api/notifications/:id` scoped to authenticated user
- **Backend pagination** – `limit`/`offset` query params on `GET /api/notifications` with total count
- **Service layer** – `PaginatedNotifications` interface, `dismissNotification()` function
- **Tests** – 15 new tests for NotificationCenter, updated 15 existing notification tests

## Related
- Closes #789
- Parent Story: #764
- Theme: #664

## Checklist
- [x] TypeScript strict – no errors
- [x] 30/30 tests passing
- [x] Lint clean
- [x] Accessible (aria-label, aria-live)
- [x] Conventional commit format