### PR TITLE
docs(security): document TLS termination ownership #794

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Task #794 — Document TLS termination ownership**: Added `docs/security/tls.md` documenting where TLS terminates (reverse proxy / ingress), required cipher suites (TLS 1.3 only), certificate source and renewal procedure, HSTS policy values (`max-age=31536000; includeSubDomains; preload`), database TLS requirements, and on-call ownership matrix. Linked from `SECURITY.md` and `README.md`. HSTS header values verified to match Helmet configuration in `backend/src/index.ts` (#794).
+
+- **Task #791 — Document Entra rollout matrix and local-fallback policy**: Added environment rollout matrix table to `docs/entra-auth-rollout.md` documenting Entra on/off, local-fallback on/off, and signing keys source for production, staging, development, and test tiers. Created operations runbook `docs/operations/entra-outage.md` with step-by-step procedure for temporarily enabling local-credential fallback during an Azure Entra ID outage, including verification, communication, and restoration steps. Added Security & Identity documentation section to README linking to the rollout matrix and outage runbook (#791).
+
 ### Added (Track B — Notifications)
 
 - **Task #786 — Notification preferences — backend model and endpoints**: Added normalised `notification_preferences` table with `(user_id, channel, category, enabled)` schema (migration `v22-notification-preferences-matrix.sql`), replacing the legacy per-type boolean columns. Migration seeds default-enabled rows for every existing user × channel × category combination. Added `GET /api/users/me/notification-preferences` returning the full channel × category matrix and `PATCH /api/users/me/notification-preferences` accepting bulk updates. Created `backend/src/services/notifications/dispatch-guard.ts` with `isChannelEnabled()` helper. Outbound dispatchers (`createBatchedNotification`, `createBudgetAlert`, `createRsvpNotification`, `createTaskDueAlert`) now consult the preference matrix before sending. Integration tests in `backend/__tests__/notification-preferences.test.ts` verify endpoints, validation, and dispatch suppression (#786).

--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ See [Branching Strategy](docs/processes/branching-strategy.md) for complete comm
 - [Contributing Guidelines](CONTRIBUTING.md) - How to contribute
 - [Code of Conduct](CODE_OF_CONDUCT.md) - Community standards
 
+### Security & Identity
+
+- [Entra Auth Rollout Matrix](docs/entra-auth-rollout.md) - Environment rollout matrix, local-fallback policy, and rollback procedures
+- [Entra Outage Runbook](docs/operations/entra-outage.md) - Temporary fallback toggle process during Entra outages
+
 ### Database Documentation
 
 - [Schema Reference](docs/database/schema.md) - Generated table/column/index/RLS reference for `public` schema
@@ -282,6 +287,7 @@ See [Branching Strategy](docs/processes/branching-strategy.md) for complete comm
 - [AGENTS.md](AGENTS.md) - Development agents and automation
 - [CHANGELOG.md](CHANGELOG.md) - Release history
 - [SECURITY.md](SECURITY.md) - Security policies
+- [docs/security/tls.md](docs/security/tls.md) - TLS termination, HSTS, and certificate ownership
 - [LICENSE](LICENSE) - MIT License
 
 ## Git Hooks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,6 +65,16 @@ Additionally, `DATABASE_URL` must use PostgreSQL with strict SSL verification:
 This ensures the 3.1.3 Data Security controls are enforced as hard startup
 requirements, not optional runtime behavior.
 
+## TLS & HTTPS
+
+TLS is terminated at the reverse-proxy / ingress layer with TLS 1.3 enforced.
+HSTS is applied by the backend via Helmet (`max-age=31536000; includeSubDomains; preload`).
+
+For full details on TLS termination, cipher suites, certificate management,
+renewal procedures, and on-call ownership, see:
+
+- **[docs/security/tls.md](docs/security/tls.md)** — TLS termination ownership and HTTPS enforcement
+
 ## Secret Management
 
 The backend uses three server-side secrets for token security. See the dedicated guide for generation, rotation, and emergency revocation procedures:

--- a/docs/security/tls.md
+++ b/docs/security/tls.md
@@ -1,0 +1,172 @@
+# TLS Termination & HTTPS Enforcement
+
+> **⚠️ DISCLAIMER: This is a fake project for demonstration/testing purposes only.**
+>
+> **No feedback will be collected or worked on. Use at your own risk.**
+
+## Overview
+
+This document describes how TLS is terminated, which cipher suites and protocol
+versions are required, where certificates originate, how they are renewed, and
+who owns the TLS stack on-call.
+
+## TLS Termination Point
+
+TLS is terminated at the **reverse-proxy / ingress layer** (e.g. cloud load
+balancer or Kubernetes Ingress controller). Neither the frontend nginx container
+nor the backend Express server handle raw TLS connections:
+
+```
+Client ──TLS 1.3──▶ Reverse Proxy / Ingress ──plaintext──▶ nginx (:80) ──▶ backend (:4000)
+```
+
+- **Frontend container** — `frontend/nginx.conf` listens on port 80 (HTTP only).
+  The `X-Forwarded-Proto` header set by the reverse proxy propagates the original
+  scheme to the backend.
+- **Backend container** — Express checks `X-Forwarded-Proto` to determine whether
+  the originating request was HTTPS. When `ENFORCE_HTTPS=true` (mandatory in
+  production/staging), insecure requests are redirected with `308 Permanent
+Redirect` or rejected with `400 Bad Request`.
+
+## Required TLS Version & Cipher Suites
+
+| Setting             | Required Value | Enforcement                                                                                  |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| Minimum TLS version | **TLS 1.3**    | `EDGE_TLS_MIN_VERSION=TLSv1.3` env var; backend startup fails if unset in production/staging |
+| TLS 1.0 / 1.1 / 1.2 | **Disabled**   | Must be disabled at the reverse proxy / ingress                                              |
+
+### Recommended Cipher Suites (TLS 1.3)
+
+TLS 1.3 cipher suites are negotiated automatically by the protocol and cannot be
+misconfigured at the application layer. The following suites are expected from
+compliant reverse proxies:
+
+| Cipher Suite                   | Key Exchange | Notes                           |
+| ------------------------------ | ------------ | ------------------------------- |
+| `TLS_AES_256_GCM_SHA384`       | ECDHE        | Preferred                       |
+| `TLS_AES_128_GCM_SHA256`       | ECDHE        | Acceptable                      |
+| `TLS_CHACHA20_POLY1305_SHA256` | ECDHE        | Acceptable (mobile performance) |
+
+> Legacy suites (CBC, RC4, 3DES, RSA key exchange) **must not** be enabled.
+
+## HSTS Policy
+
+HTTP Strict Transport Security is enforced by the backend via the
+[Helmet](https://helmetjs.github.io/) middleware in `backend/src/index.ts`:
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+| Directive           | Value               | Meaning                                                           |
+| ------------------- | ------------------- | ----------------------------------------------------------------- |
+| `max-age`           | `31536000` (1 year) | Browsers must use HTTPS for all future requests for this duration |
+| `includeSubDomains` | `true`              | Policy applies to all subdomains                                  |
+| `preload`           | `true`              | Domain is eligible for browser HSTS preload lists                 |
+
+### Code Reference
+
+```typescript
+// backend/src/index.ts
+app.use(
+  helmet({
+    hsts: {
+      maxAge: 31536000,
+      includeSubDomains: true,
+      preload: true,
+    },
+  }),
+);
+```
+
+### Verification
+
+```bash
+# Check HSTS header against a running instance
+curl -sI https://<hostname>/health | grep -i strict-transport-security
+# Expected: strict-transport-security: max-age=31536000; includeSubDomains; preload
+```
+
+Test coverage is in `backend/__tests__/helmet-security-headers.test.ts`.
+
+## HTTPS Enforcement
+
+The backend enforces HTTPS when `ENFORCE_HTTPS=true` (mandatory in
+production/staging via `backend/src/config/security-controls.ts`):
+
+- **GET / HEAD** requests over HTTP are redirected to HTTPS with `308 Permanent
+Redirect`.
+- **All other methods** over HTTP receive `400 Bad Request` with
+  `{ "error": "HTTPS is required for this endpoint." }`.
+
+## Certificate Source
+
+| Item                  | Value                                                                              |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| Certificate Authority | Cloud-managed (e.g. AWS ACM, Azure App Service Managed Certificate, Let's Encrypt) |
+| Certificate type      | Domain-validated (DV) wildcard or SAN certificate                                  |
+| Key algorithm         | ECDSA P-256 (preferred) or RSA 2048-bit minimum                                    |
+| Storage               | Cloud provider secret store (e.g. AWS ACM, Azure Key Vault)                        |
+
+> Private keys **must never** be committed to source control or stored on
+> application containers.
+
+## Certificate Renewal Procedure
+
+| Step | Description                                                                                                                                |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | Cloud-managed certificates auto-renew 30 days before expiry                                                                                |
+| 2    | For manually provisioned certificates: generate a new CSR, submit to CA, and deploy the renewed certificate to the load balancer / ingress |
+| 3    | Verify renewal via `openssl s_client -connect <hostname>:443` and confirm the `Not After` date                                             |
+| 4    | Monitor certificate expiry with infrastructure alerting (e.g. CloudWatch, Azure Monitor) with a 14-day warning threshold                   |
+
+### Renewal Verification
+
+```bash
+# Check certificate expiry date
+echo | openssl s_client -connect <hostname>:443 -servername <hostname> 2>/dev/null \
+  | openssl x509 -noout -dates
+```
+
+## Database TLS
+
+PostgreSQL connections must use encrypted transport in production/staging:
+
+| Setting                     | Required Value               | Enforcement                                          |
+| --------------------------- | ---------------------------- | ---------------------------------------------------- |
+| `DB_SSL_REQUIRED`           | `true`                       | Backend startup fails if unset in production/staging |
+| `sslmode` in `DATABASE_URL` | `verify-ca` or `verify-full` | Validates server certificate against trusted CA      |
+
+See `backend/src/config/security-controls.ts` for the full list of mandatory
+security flags.
+
+## On-Call Ownership
+
+| Area                                     | Owner                               | Responsibility                                                                 |
+| ---------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------ |
+| Reverse proxy / ingress TLS config       | **Platform / Infrastructure team**  | Certificate provisioning, cipher suite policy, TLS version enforcement         |
+| HSTS and HTTPS enforcement (application) | **Backend team**                    | Helmet config, redirect middleware, security-controls startup gates            |
+| Database TLS (`sslmode`)                 | **Platform / Infrastructure team**  | PostgreSQL server certificate management, `pg_hba.conf` TLS enforcement        |
+| Certificate monitoring & alerts          | **Platform / Infrastructure team**  | Alerting on upcoming expiry, failed renewals                                   |
+| Incident response (TLS-related)          | **On-call SRE / Platform engineer** | Rotate certificates, update cipher policies, coordinate with CA if compromised |
+
+## Mandatory Production Environment Variables
+
+All of the following must be set for the backend to start in production/staging
+(enforced by `backend/src/config/security-controls.ts`):
+
+```env
+ENFORCE_HTTPS=true
+EDGE_TLS_MIN_VERSION=TLSv1.3
+DB_SSL_REQUIRED=true
+DB_ENCRYPTION_AT_REST_VERIFIED=true
+```
+
+See [SECURITY.md](../../SECURITY.md) for the complete list of mandatory
+production security flags.
+
+## Related Documentation
+
+- [SECURITY.md](../../SECURITY.md) — Security policies and mandatory production flags
+- [JWT Secrets](jwt-secrets.md) — Token secret lifecycle and rotation
+- [Password Hashing](../../PASSWORD_HASHING.md) — bcrypt configuration


### PR DESCRIPTION
## Summary

Adds comprehensive TLS termination ownership documentation as required by Task #794.

## Changes

- **`docs/security/tls.md` (new)** — Documents where TLS terminates (reverse proxy / ingress), required cipher suites (TLS 1.3 only), HSTS policy values, certificate source and renewal procedure, database TLS requirements, and on-call ownership matrix.
- **`SECURITY.md`** — Added TLS & HTTPS section linking to the new TLS doc.
- **`README.md`** — Added TLS doc link in the Project Information section.
- **`CHANGELOG.md`** — Added entry under [Unreleased] Documentation section.

## Acceptance Criteria Verification

- [x] `docs/security/tls.md` documents: where TLS terminates (reverse proxy / ingress), required cipher suites, cert source, renewal procedure, who owns it on-call
- [x] Linked from `SECURITY.md` and `README.md`
- [x] HSTS header values match doc and code (`max-age=31536000; includeSubDomains; preload`)
- [x] CHANGELOG entry

## Related Issues

Closes #794
Parent Story: #764
Theme: #664