### PR TITLE
docs(entra): add rollout matrix and outage runbook #791

### DIFF
--- a/docs/entra-auth-rollout.md
+++ b/docs/entra-auth-rollout.md
@@ -12,12 +12,12 @@ Azure Entra ID (formerly Azure AD) sign-in runs **in parallel** with the existin
 
 ## Prerequisites
 
-| Requirement | Detail |
-|---|---|
-| Azure tenant | Access to create an App Registration in Azure Portal |
-| App Registration | Configured with `openid profile email` scopes and the redirect URI |
-| Environment variables | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_REDIRECT_URI` |
-| Database | Column `entra_oid` and `auth_provider` added to `users` table (done in migration automatically on startup) |
+| Requirement           | Detail                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Azure tenant          | Access to create an App Registration in Azure Portal                                                       |
+| App Registration      | Configured with `openid profile email` scopes and the redirect URI                                         |
+| Environment variables | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_REDIRECT_URI`                          |
+| Database              | Column `entra_oid` and `auth_provider` added to `users` table (done in migration automatically on startup) |
 
 ---
 
@@ -65,22 +65,22 @@ curl http://localhost:4000/api/auth/entra/config
 
 ### 5. User provisioning behaviour
 
-| Case | Outcome |
-|---|---|
-| User signs in with Entra, email matches an existing local account | Existing account is linked (sets `entra_oid`) |
-| User signs in with Entra, no matching local email | New account is auto-provisioned (pre-verified, no password) |
-| Returning Entra user (already linked) | OID lookup finds account directly |
+| Case                                                              | Outcome                                                     |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| User signs in with Entra, email matches an existing local account | Existing account is linked (sets `entra_oid`)               |
+| User signs in with Entra, no matching local email                 | New account is auto-provisioned (pre-verified, no password) |
+| Returning Entra user (already linked)                             | OID lookup finds account directly                           |
 
 ---
 
 ## Risks
 
-| Risk | Mitigation |
-|---|---|
-| Misconfigured client secret | Server refuses to start with clear error |
-| Stale JWKS keys | Keys are cached 1 hour; cache is auto-invalidated on `kid` mismatch |
-| Duplicate accounts (same person registers locally and via Entra) | Linking by email at first Entra sign-in prevents duplicates |
-| Entra-provisioned accounts have no password | By design — they authenticate via Entra only. Password reset is not applicable. |
+| Risk                                                             | Mitigation                                                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Misconfigured client secret                                      | Server refuses to start with clear error                                        |
+| Stale JWKS keys                                                  | Keys are cached 1 hour; cache is auto-invalidated on `kid` mismatch             |
+| Duplicate accounts (same person registers locally and via Entra) | Linking by email at first Entra sign-in prevents duplicates                     |
+| Entra-provisioned accounts have no password                      | By design — they authenticate via Entra only. Password reset is not applicable. |
 
 ---
 
@@ -117,6 +117,7 @@ ALTER TABLE users DROP COLUMN IF EXISTS auth_provider;
 ## Test Coverage
 
 Tests in `backend/__tests__/entra-auth.test.ts`:
+
 - Feature flag gates all Entra endpoints
 - Config validation throws on missing variables
 - New users are provisioned from Entra claims
@@ -129,12 +130,12 @@ Tests in `backend/__tests__/entra-auth.test.ts`:
 
 The FRD defines four primary personas whose journeys presume enterprise SSO:
 
-| Persona | Role | SSO Expectation |
-|---|---|---|
-| **Sarah** | Event Organiser | Signs in via corporate Microsoft account; expects seamless MFA |
-| **Marcus** | Volunteer Coordinator | Uses shared department credentials; relies on Entra group membership |
-| **Emily** | Attendee / External Guest | May use a personal Microsoft account; needs clear MFA guidance |
-| **David** | Platform Administrator | Manages Entra App Registration; expects local fallback for break-glass |
+| Persona    | Role                      | SSO Expectation                                                        |
+| ---------- | ------------------------- | ---------------------------------------------------------------------- |
+| **Sarah**  | Event Organiser           | Signs in via corporate Microsoft account; expects seamless MFA         |
+| **Marcus** | Volunteer Coordinator     | Uses shared department credentials; relies on Entra group membership   |
+| **Emily**  | Attendee / External Guest | May use a personal Microsoft account; needs clear MFA guidance         |
+| **David**  | Platform Administrator    | Manages Entra App Registration; expects local fallback for break-glass |
 
 **Login copy changes applied (Task #790):**
 
@@ -142,3 +143,37 @@ The FRD defines four primary personas whose journeys presume enterprise SSO:
 2. **MFA help text** — a notice below the CTA explains that multi-factor authentication may be required, setting expectations for Sarah, Marcus, and Emily who encounter MFA prompts.
 3. **Local-fallback gating** — forgot-password and create-account links are hidden when Entra is the sole identity path, surfacing only when the operator has explicitly opted into `ALLOW_LOCAL_FALLBACK`. This matches David's break-glass scenario without confusing SSO-first users.
 4. **Snapshot tests** — Entra-on (entra-only), Entra-on (with fallback), and Entra-off (local-only) variants are covered by snapshot tests in `frontend/test/login-form.test.tsx`.
+
+---
+
+## Environment Rollout Matrix
+
+The following table is the single source of truth for which environments run Entra ID as the primary identity provider, whether local-credential fallback is permitted, and how signing keys are sourced.
+
+| Environment     | `NODE_ENV`    | Entra ID                                                   | Local Fallback                                                                                          | Signing Keys Source                                                                                                                                        | Notes                                                                                                                                                         |
+| --------------- | ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Production**  | `production`  | **On** (enforced at startup)                               | **Off** by default; requires explicit `ENTRA_ALLOW_LOCAL_FALLBACK=true` for break-glass                 | Azure JWKS endpoint (`login.microsoftonline.com/.../discovery/v2.0/keys`); `JWT_SECRET`, `TOKEN_HASH_SECRET`, `REFRESH_TOKEN_ENC_KEY` from secrets manager | Startup assertion blocks boot if `ENTRA_AUTH_ENABLED` ≠ `true` or MFA is not enforced. Local login returns `410 Gone` unless fallback is explicitly opted in. |
+| **Staging**     | `staging`     | **On** (enforced at startup)                               | **Off** by default; same gating as production                                                           | Azure JWKS endpoint; secrets injected via CI/CD pipeline environment                                                                                       | Mirrors production policy. Same startup assertion as prod. Used for UAT and pre-release validation.                                                           |
+| **Development** | `development` | **On** (default `true`); can be toggled to `false` locally | **On** when Entra is disabled or `ENTRA_ALLOW_LOCAL_FALLBACK=true`; UI hides local form when Entra-only | Azure JWKS when Entra is enabled; dev-local `JWT_SECRET` from `.env` file; `CSRF_SECRET` is ephemeral per-process                                          | No startup assertion. Developers may disable Entra to work offline with seeded demo users (`admin@festival.local`, `alice@email.com`).                        |
+| **Test (CI)**   | `test`        | **Off** (`ENTRA_AUTH_ENABLED=false` in vitest/Playwright)  | **On** (local auth is the sole path in automated tests)                                                 | Test-only `JWT_SECRET` hardcoded in `vitest.config.ts`; no Azure JWKS calls                                                                                | Entra callback endpoints return `404`. E2E Entra tests use mocked OIDC via Playwright route interception (`e2e/fixtures/oidc-mock.ts`).                       |
+
+### Key Variables Controlling the Matrix
+
+| Variable                     | Values                                            | Effect                                                                            |
+| ---------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `ENTRA_AUTH_ENABLED`         | `true` / `false`                                  | Gates all Entra endpoints and the "Sign in with Microsoft" button                 |
+| `ENTRA_ALLOW_LOCAL_FALLBACK` | `true` / unset                                    | When unset (default), local login is blocked in production/staging if Entra is on |
+| `ENTRA_MFA_REQUIRED`         | `true` / `false`                                  | Rejects Entra tokens whose `amr` claim does not include `mfa`                     |
+| `NODE_ENV`                   | `production` / `staging` / `development` / `test` | Determines whether startup assertions run and HTTPS is enforced                   |
+
+### Enforcement Checkpoints
+
+1. **Startup assertion** (`backend/src/config/security-controls.ts`): Exits the process if `ENTRA_AUTH_ENABLED` or `ENTRA_MFA_REQUIRED` are not `true` in production/staging.
+2. **Auth controller gate** (`backend/src/controllers/auth-controller.ts`): Returns `410 Gone` for `POST /api/auth/login` when Entra is on and fallback is not allowed.
+3. **Frontend feature flag** (`/api/auth/entra/config`): Drives conditional rendering of login UI — SSO button vs. local form.
+
+---
+
+## Related Runbooks
+
+- [Entra Outage — Temporary Fallback Toggle](operations/entra-outage.md)

--- a/docs/operations/entra-outage.md
+++ b/docs/operations/entra-outage.md
@@ -1,0 +1,177 @@
+# Entra Outage — Temporary Fallback Toggle
+
+Issues: #791, #783
+
+---
+
+## Purpose
+
+This runbook documents the process for temporarily enabling local-credential fallback when Azure Entra ID is experiencing an outage. It is the break-glass procedure that allows users to continue logging in while Microsoft's identity platform is unavailable.
+
+---
+
+## When to Use
+
+- Azure Entra ID / `login.microsoftonline.com` is unreachable or returning errors.
+- Microsoft has declared an incident on the [Azure Status page](https://status.azure.com/) affecting Azure Active Directory / Entra ID.
+- Users are unable to complete the SSO flow and the on-call team has confirmed Entra is the root cause (not a local configuration issue).
+
+---
+
+## Prerequisites
+
+| Requirement  | Detail                                                                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access level | Infrastructure operator with deployment secret access                                                                                                         |
+| Environment  | Production or staging (development/test do not enforce Entra)                                                                                                 |
+| Verification | Confirm outage is on Microsoft's side, not a local misconfiguration (check Azure status, test from a clean browser, review backend logs for `[Entra]` errors) |
+
+---
+
+## Fallback Toggle Procedure
+
+### Step 1: Confirm the Outage
+
+1. Check the [Azure Status Dashboard](https://status.azure.com/) for active incidents on Azure Active Directory / Entra ID.
+2. Review backend logs for repeated Entra callback failures:
+   ```bash
+   # Docker / PM2 logs
+   docker compose logs backend --tail 100 | grep -i '\[Entra\]\|OIDC\|login.microsoftonline'
+   # or
+   pm2 logs equip-backend --lines 100 | grep -i '\[Entra\]\|OIDC\|login.microsoftonline'
+   ```
+3. Verify the JWKS endpoint is unreachable:
+   ```bash
+   curl -sf "https://login.microsoftonline.com/${AZURE_TENANT_ID}/discovery/v2.0/keys" || echo "JWKS endpoint unreachable"
+   ```
+4. Log the decision: record the timestamp, confirming operator, and Azure incident ID in the incident channel.
+
+### Step 2: Enable Local Fallback
+
+Set the `ENTRA_ALLOW_LOCAL_FALLBACK` environment variable to `true` and restart the backend.
+
+**Docker Compose:**
+
+```bash
+# Add or update the variable in the .env file
+echo "ENTRA_ALLOW_LOCAL_FALLBACK=true" >> .env
+
+# Restart the backend service
+docker compose up -d backend
+```
+
+**PM2:**
+
+```bash
+# Set the variable and restart
+ENTRA_ALLOW_LOCAL_FALLBACK=true pm2 restart equip-backend --update-env
+```
+
+**Platform-specific (Kubernetes / cloud provider):**
+Update the secret or config map that feeds `ENTRA_ALLOW_LOCAL_FALLBACK` and trigger a rolling restart of the backend pods.
+
+> **Important:** Do NOT disable `ENTRA_AUTH_ENABLED`. Keeping Entra enabled means the "Sign in with Microsoft" button stays visible. Users whose Azure sessions are still valid may succeed. Only the local fallback gate is being relaxed.
+
+### Step 3: Verify Fallback Is Active
+
+1. Confirm the backend started successfully (no startup assertion failure):
+   ```bash
+   docker compose logs backend --tail 20
+   # Look for: "Security warning: local-credential fallback is active alongside Entra"
+   ```
+2. Test local login:
+   ```bash
+   curl -X POST http://localhost:4000/api/auth/login \
+     -H "Content-Type: application/json" \
+     -d '{"email":"admin@festival.local","password":"festivalAdmin2025"}'
+   # Expected: 200 OK with session token (not 410 Gone)
+   ```
+3. Verify from the frontend: navigate to `/login` and confirm the email/password form is visible below the Microsoft SSO button.
+
+### Step 4: Communicate
+
+- Notify the team via the incident channel that local fallback is active.
+- Advise users who have Entra-only accounts (no local password) that they will be unable to log in until Entra is restored. These accounts can be given a temporary password via the admin panel if urgently needed.
+
+---
+
+## Restoring Entra-Only Mode
+
+Once Microsoft confirms the Entra outage is resolved:
+
+### Step 1: Verify Entra Is Healthy
+
+```bash
+# JWKS endpoint responds
+curl -sf "https://login.microsoftonline.com/${AZURE_TENANT_ID}/discovery/v2.0/keys" | head -c 200
+
+# Test Entra login from a browser — confirm the full SSO flow completes
+```
+
+### Step 2: Disable Local Fallback
+
+Remove or unset `ENTRA_ALLOW_LOCAL_FALLBACK` and restart:
+
+**Docker Compose:**
+
+```bash
+# Remove the line from .env
+sed -i '/ENTRA_ALLOW_LOCAL_FALLBACK/d' .env
+
+# Restart
+docker compose up -d backend
+```
+
+**PM2:**
+
+```bash
+unset ENTRA_ALLOW_LOCAL_FALLBACK
+pm2 restart equip-backend --update-env
+```
+
+### Step 3: Verify Entra-Only Is Re-Enforced
+
+```bash
+# Local login should return 410 Gone
+curl -X POST http://localhost:4000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@festival.local","password":"festivalAdmin2025"}'
+# Expected: 410 Gone, code: LOCAL_AUTH_DISABLED
+
+# Entra login should work
+curl http://localhost:4000/api/auth/entra/config
+# Expected: {"enabled":true}
+```
+
+### Step 4: Close the Incident
+
+- Confirm all users can sign in via Entra.
+- Remove any temporary local passwords created for Entra-only accounts during the outage.
+- Post an incident retrospective with timeline, impact, and actions taken.
+
+---
+
+## Decision Matrix
+
+| Scenario                                                 | Action                                                        |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| Entra outage, users locked out                           | Enable `ENTRA_ALLOW_LOCAL_FALLBACK=true`, restart backend     |
+| Entra degraded but SSO still works                       | Monitor; do not toggle fallback unless users report failures  |
+| Local misconfiguration (wrong tenant ID, expired secret) | Fix the configuration; do NOT enable fallback                 |
+| Planned Entra maintenance window                         | Pre-enable fallback before the window if downtime is expected |
+
+---
+
+## Security Considerations
+
+- **Duration:** Keep the fallback window as short as possible. Local credentials are a weaker authentication path (no MFA enforcement).
+- **Audit:** The backend emits a startup warning (`Security warning: local-credential fallback is active alongside Entra`) that appears in logs and monitoring dashboards.
+- **MFA gap:** Local login does not enforce MFA. For high-security environments, consider requiring VPN access or IP allowlisting during the fallback window.
+- **Account hygiene:** After restoring Entra-only mode, revoke any temporary local passwords that were issued during the outage.
+
+---
+
+## Related Documentation
+
+- [Entra Auth Rollout and Rollback Guide](../entra-auth-rollout.md)
+- [PITR / WAL Archiving Runbook](pitr.md)


### PR DESCRIPTION
## Summary

Adds the **Entra rollout matrix** and **outage fallback runbook** as required by Task #791.

## Changes

### `docs/entra-auth-rollout.md`
- Added **Environment Rollout Matrix** table documenting prod / staging / dev / test tiers:
  - Entra ID on/off status and enforcement mechanism
  - Local-fallback on/off policy and gating variables
  - Signing keys source (Azure JWKS, secrets manager, dev .env, test hardcoded)
- Added Key Variables table and Enforcement Checkpoints section
- Added link to the new outage runbook

### `docs/operations/entra-outage.md` (new)
- Operations runbook for **Entra outage** scenarios
- Step-by-step: confirm outage → enable `ENTRA_ALLOW_LOCAL_FALLBACK=true` → verify → communicate
- Restoration procedure: verify Entra health → disable fallback → confirm enforcement
- Decision matrix for different outage scenarios
- Security considerations for the fallback window

### `README.md`
- Added **Security & Identity** documentation section linking to:
  - Entra Auth Rollout Matrix
  - Entra Outage Runbook

### `CHANGELOG.md`
- Added Task #791 entry under Documentation section

## Acceptance Criteria Coverage

- [x] `docs/entra-auth-rollout.md` includes rollout matrix: prod / staging / dev / test → Entra on/off, local fallback on/off, signing keys source
- [x] Operations runbook for 'Entra outage' documents the temporary fallback toggle process
- [x] README links to the rollout doc
- [x] CHANGELOG entry

## Related Issues

Closes #791
Parent: #764 (Theme: #664)