### PR TITLE
feat(notifications): in-app notification toast component #788

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import PublicRsvpPage from './components/events/public-rsvp-page';
 import ProfilePage from './components/profile/profile-page';
 import AdminPage from './components/admin/admin-page';
 import { AiAssistant } from './components/ai/ai-assistant';
+import { NotificationToast } from './components/nav/notification-toast';
 import { AnalyticsPage } from './components/analytics/analytics-page';
 import EventFormPage from './components/events/event-form-page';
 import VendorsPage from './components/vendors/vendors-page';
@@ -539,6 +540,7 @@ function AppShell(): JSX.Element {
         </ErrorBoundary>
       </Box>
       <AiAssistant />
+      <NotificationToast />
       <GlobalShortcuts
         onToggleHelp={handleToggleHelp}
         onOpenHelp={handleOpenHelp}

--- a/frontend/src/components/nav/notification-toast.tsx
+++ b/frontend/src/components/nav/notification-toast.tsx
@@ -1,0 +1,184 @@
+/**
+ * NotificationToast — global toast container driven by the SSE realtime stream.
+ *
+ * Subscribes to SSE topics and pushes incoming notifications into a queue
+ * rendered as stacked MUI Snackbar/Alert toasts.
+ *
+ * - Auto-dismiss after 6 s
+ * - Pause timer on hover
+ * - Manual dismiss via close button
+ * - Accessible via role="status" polite live region
+ *
+ * Task #788
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, IconButton, Slide, Snackbar, Stack } from '@mui/material';
+import type { SlideProps } from '@mui/material/Slide';
+import CloseRounded from '@mui/icons-material/CloseRounded';
+import { useRealtime, type RealtimeMessage } from '../../hooks/use-realtime';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Toast {
+  id: string;
+  message: string;
+  severity: 'success' | 'error' | 'warning' | 'info';
+  /** ISO timestamp when the toast was created. */
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AUTO_DISMISS_MS = 6_000;
+const MAX_VISIBLE = 5;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SlideUp(props: SlideProps): JSX.Element {
+  return <Slide {...props} direction="up" />;
+}
+
+function severityFromType(type: string): Toast['severity'] {
+  if (type.startsWith('budget')) return 'warning';
+  if (type.includes('error') || type.includes('fail')) return 'error';
+  if (type.includes('complete') || type.includes('success')) return 'success';
+  return 'info';
+}
+
+function titleFromMessage(msg: RealtimeMessage): string {
+  const payload = msg.payload as Record<string, unknown>;
+  if (typeof payload.title === 'string' && payload.title) return payload.title;
+  if (typeof payload.message === 'string' && payload.message) return payload.message;
+  return msg.type.replace(/[._-]/g, ' ');
+}
+
+let nextId = 0;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NotificationToast(): JSX.Element {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const hoveredRef = useRef<Set<string>>(new Set());
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    hoveredRef.current.delete(id);
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const scheduleAutoDismiss = useCallback(
+    (id: string) => {
+      const timer = setTimeout(() => {
+        if (hoveredRef.current.has(id)) return;
+        dismiss(id);
+      }, AUTO_DISMISS_MS);
+      timersRef.current.set(id, timer);
+    },
+    [dismiss],
+  );
+
+  const push = useCallback(
+    (message: string, severity: Toast['severity'] = 'info') => {
+      const id = `toast-${Date.now()}-${++nextId}`;
+      const toast: Toast = { id, message, severity, createdAt: Date.now() };
+      setToasts((prev) => [...prev.slice(-(MAX_VISIBLE - 1)), toast]);
+      scheduleAutoDismiss(id);
+    },
+    [scheduleAutoDismiss],
+  );
+
+  const handleMouseEnter = useCallback((id: string) => {
+    hoveredRef.current.add(id);
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const handleMouseLeave = useCallback(
+    (id: string) => {
+      hoveredRef.current.delete(id);
+      scheduleAutoDismiss(id);
+    },
+    [scheduleAutoDismiss],
+  );
+
+  // Clean up all timers on unmount
+  useEffect(() => {
+    return () => {
+      for (const timer of timersRef.current.values()) clearTimeout(timer);
+    };
+  }, []);
+
+  // SSE subscription — push incoming events as toasts
+  const handleMessage = useCallback(
+    (msg: RealtimeMessage) => {
+      push(titleFromMessage(msg), severityFromType(msg.type));
+    },
+    [push],
+  );
+
+  useRealtime(['events', 'tasks', 'budgets', 'activity'], handleMessage);
+
+  const visible = toasts.slice(-MAX_VISIBLE);
+
+  return (
+    <Stack
+      spacing={1}
+      role="status"
+      aria-live="polite"
+      aria-label="Notification toasts"
+      sx={{
+        position: 'fixed',
+        bottom: 24,
+        right: 24,
+        zIndex: (theme) => theme.zIndex.snackbar + 1,
+        pointerEvents: 'none',
+      }}
+    >
+      {visible.map((toast) => (
+        <Snackbar
+          key={toast.id}
+          open
+          TransitionComponent={SlideUp}
+          sx={{ position: 'static', pointerEvents: 'auto' }}
+        >
+          <Alert
+            severity={toast.severity}
+            variant="filled"
+            onMouseEnter={() => handleMouseEnter(toast.id)}
+            onMouseLeave={() => handleMouseLeave(toast.id)}
+            action={
+              <IconButton
+                size="small"
+                color="inherit"
+                aria-label="Dismiss notification"
+                onClick={() => dismiss(toast.id)}
+              >
+                <CloseRounded fontSize="small" />
+              </IconButton>
+            }
+            sx={{ width: 360, maxWidth: 'calc(100vw - 48px)' }}
+          >
+            {toast.message}
+          </Alert>
+        </Snackbar>
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/test/notification-toast.test.tsx
+++ b/frontend/test/notification-toast.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Tests for NotificationToast component
+ * Task #788
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { NotificationToast } from '../src/components/nav/notification-toast';
+import type { Toast } from '../src/components/nav/notification-toast';
+
+// Mock useRealtime — capture the onMessage callback so tests can invoke it
+let capturedOnMessage: ((msg: unknown) => void) | null = null;
+
+vi.mock('../src/hooks/use-realtime', () => ({
+  useRealtime: (_topics: string[], onMessage: (msg: unknown) => void) => {
+    capturedOnMessage = onMessage;
+    return { connected: true };
+  },
+}));
+
+function pushSSE(type: string, payload: Record<string, unknown> = {}): void {
+  act(() => {
+    capturedOnMessage?.({
+      topic: 'events',
+      type,
+      payload,
+      occurredAt: new Date().toISOString(),
+    });
+  });
+}
+
+describe('NotificationToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    capturedOnMessage = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when there are no toasts', () => {
+    render(<NotificationToast />);
+    const container = screen.getByRole('status');
+    expect(container).toBeDefined();
+    expect(container.children.length).toBe(0);
+  });
+
+  it('renders a toast when an SSE message arrives', () => {
+    render(<NotificationToast />);
+    pushSSE('event.created', { title: 'New event created' });
+    expect(screen.getByText('New event created')).toBeDefined();
+  });
+
+  it('assigns correct severity for budget messages', () => {
+    render(<NotificationToast />);
+    pushSSE('budget.warning', { title: 'Budget exceeded' });
+    const alert = screen.getByRole('alert');
+    // MUI filled Alert has severity in data attribute or ARIA
+    expect(alert.textContent).toContain('Budget exceeded');
+  });
+
+  it('assigns info severity by default', () => {
+    render(<NotificationToast />);
+    pushSSE('some.event', { title: 'Something happened' });
+    const alert = screen.getByRole('alert');
+    // MUI filled Alert has severity in data attribute or ARIA
+    expect(alert.textContent).toContain('Something happened');
+  });
+
+  it('auto-dismisses after 6 seconds', async () => {
+    render(<NotificationToast />);
+    pushSSE('event.updated', { title: 'Auto dismiss me' });
+    expect(screen.getByText('Auto dismiss me')).toBeDefined();
+
+    act(() => {
+      vi.advanceTimersByTime(6_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Auto dismiss me')).toBeNull();
+    });
+  });
+
+  it('pauses auto-dismiss on hover and resumes on leave', async () => {
+    render(<NotificationToast />);
+    pushSSE('task.created', { title: 'Hover me' });
+    const alert = screen.getByRole('alert');
+
+    // Hover at 3s
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    fireEvent.mouseEnter(alert);
+
+    // Wait past 6s total — should still be there
+    act(() => {
+      vi.advanceTimersByTime(4_000);
+    });
+    expect(screen.getByText('Hover me')).toBeDefined();
+
+    // Mouse leave — should dismiss after another 6s
+    fireEvent.mouseLeave(alert);
+    act(() => {
+      vi.advanceTimersByTime(6_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Hover me')).toBeNull();
+    });
+  });
+
+  it('manually dismisses on close button click', () => {
+    render(<NotificationToast />);
+    pushSSE('event.deleted', { title: 'Dismiss me' });
+    expect(screen.getByText('Dismiss me')).toBeDefined();
+
+    const btn = screen.getByRole('button', { name: /dismiss/i });
+    fireEvent.click(btn);
+    expect(screen.queryByText('Dismiss me')).toBeNull();
+  });
+
+  it('limits visible toasts to MAX_VISIBLE (5)', () => {
+    render(<NotificationToast />);
+    for (let i = 0; i < 7; i++) {
+      pushSSE('event.created', { title: `Toast ${i}` });
+    }
+    const container = screen.getByRole('status');
+    // Only 5 toasts visible (the last 5)
+    expect(container.children.length).toBe(5);
+    expect(screen.queryByText('Toast 0')).toBeNull();
+    expect(screen.queryByText('Toast 1')).toBeNull();
+    expect(screen.getByText('Toast 6')).toBeDefined();
+  });
+
+  it('has role="status" with aria-live="polite"', () => {
+    render(<NotificationToast />);
+    const container = screen.getByRole('status');
+    expect(container.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('uses message payload for toast text', () => {
+    render(<NotificationToast />);
+    pushSSE('task.updated', { message: 'Task was updated' });
+    expect(screen.getByText('Task was updated')).toBeDefined();
+  });
+
+  it('falls back to type name when no title/message in payload', () => {
+    render(<NotificationToast />);
+    pushSSE('activity.new_comment', {});
+    expect(screen.getByText('activity new comment')).toBeDefined();
+  });
+
+  it('queues multiple toasts and dismisses them independently', async () => {
+    render(<NotificationToast />);
+    pushSSE('event.a', { title: 'First' });
+    pushSSE('event.b', { title: 'Second' });
+    expect(screen.getByText('First')).toBeDefined();
+    expect(screen.getByText('Second')).toBeDefined();
+
+    // Dismiss only the first
+    const buttons = screen.getAllByRole('button', { name: /dismiss/i });
+    fireEvent.click(buttons[0]);
+    expect(screen.queryByText('First')).toBeNull();
+    expect(screen.getByText('Second')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Implements Task #788 — In-app notification toast component driven by SSE realtime stream.

## Changes
- **NotificationToast component** — Global toast container that subscribes to SSE topics (`events`, `tasks`, `budgets`, `activity`) via `useRealtime` hook and renders stacked MUI Snackbar/Alert toasts
- **Features**: Auto-dismiss after 6s, pause timer on hover, manual dismiss via close button, max 5 visible toasts, severity mapped from event type
- **Accessibility**: `role="status"` + `aria-live="polite"` live region
- **App.tsx**: Mount `NotificationToast` globally alongside other global components
- **Tests**: 12 unit tests covering queue behaviour, auto-dismissal, hover pause, overflow, manual dismiss

## Related
- Closes #788
- Parent Story: #764
- Theme: #664

## Checklist
- [x] TypeScript strict — no errors
- [x] 12/12 tests passing
- [x] Accessible (role="status", aria-live)
- [x] Conventional commit format