### PR TITLE
fix(tasks): [TASK] align urgent priority parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Task #780 — Align task priority parity for `Urgent`**: Added migration `database/migrations/v23-task-priority-urgent-780.sql` and runtime/bootstrap schema updates so both `tasks.priority` and `task_templates.priority` accept `Urgent`. Backend task and task-template validation now allow the value, frontend task priority pickers now expose `Urgent` with a stronger visual treatment, and tests cover urgent-priority create/update flows (#780).
 - **Issue #770 — Collapse dual RSVP status columns to single source of truth**: Consolidated `rsvps.status` (legacy) and `rsvps.canonical_status` (canonical) columns by dropping the legacy `status` column entirely. `canonical_status` is now the single source of truth with values `pending`, `confirmed`, `declined`, `maybe`, `waitlist`, `cancelled`, `checked_in`, `no_show`. All backend controllers updated to read/write canonical_status only; legacy status input is still accepted and mapped to canonical via `toCanonicalStatus()` for backward compatibility. Frontend types updated to use canonical_status instead of status. Database migration `v21-rsvp-status-collapse.sql` backfills any remaining NULL canonical_status values and drops the status column. All RSVP-related tests and seed data updated. Issue addresses data consistency issues where dual columns could diverge (#770).
 
 ### Added (Track D — Real-time)

--- a/backend/__tests__/multi-assignee-tasks.test.ts
+++ b/backend/__tests__/multi-assignee-tasks.test.ts
@@ -88,17 +88,30 @@ beforeEach(async () => {
   }));
 
   const usersRows = await Promise.all([
-    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('alice@example.com', 'Alice') RETURNING id`),
-    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('bob@example.com', 'Bob') RETURNING id`),
-    testDb!.run(`INSERT INTO users (email, display_name) VALUES ('carol@example.com', 'Carol') RETURNING id`),
+    testDb!.run(
+      `INSERT INTO users (email, display_name) VALUES ('alice@example.com', 'Alice') RETURNING id`,
+    ),
+    testDb!.run(
+      `INSERT INTO users (email, display_name) VALUES ('bob@example.com', 'Bob') RETURNING id`,
+    ),
+    testDb!.run(
+      `INSERT INTO users (email, display_name) VALUES ('carol@example.com', 'Carol') RETURNING id`,
+    ),
   ]);
   alice = usersRows[0].lastID!;
   bob = usersRows[1].lastID!;
   carol = usersRows[2].lastID!;
-  const ev = await testDb!.run(`INSERT INTO events (title, created_by) VALUES ('Ev', $1) RETURNING id`, [alice]);
+  const ev = await testDb!.run(
+    `INSERT INTO events (title, created_by) VALUES ('Ev', $1) RETURNING id`,
+    [alice],
+  );
   eventId = ev.lastID!;
   for (const u of [alice, bob, carol]) {
-    await testDb!.run('INSERT INTO event_members (event_id, user_id, role) VALUES ($1,$2,$3)', [eventId, u, 'Member']);
+    await testDb!.run('INSERT INTO event_members (event_id, user_id, role) VALUES ($1,$2,$3)', [
+      eventId,
+      u,
+      'Member',
+    ]);
   }
 });
 
@@ -141,7 +154,9 @@ describe('multi-assignee tasks API (B1.2)', () => {
     );
     await createTask(req as unknown as Parameters<typeof createTask>[0], res);
     expect(res.statusCode).toBe(201);
-    const created = (res.body as { task: { id: number; assigned_user_id: number; assignees: unknown[] } }).task;
+    const created = (
+      res.body as { task: { id: number; assigned_user_id: number; assignees: unknown[] } }
+    ).task;
     expect(created.assigned_user_id).toBe(bob); // primary mirrored
     expect(created.assignees).toHaveLength(2);
 
@@ -158,7 +173,10 @@ describe('multi-assignee tasks API (B1.2)', () => {
     const { createTask } = await import('../src/controllers/tasks-controller.js');
     const res = makeRes();
     await createTask(
-      makeReq({ eventId: String(eventId) }, { title: 't', assigned_user_id: carol }) as unknown as Parameters<typeof createTask>[0],
+      makeReq(
+        { eventId: String(eventId) },
+        { title: 't', assigned_user_id: carol },
+      ) as unknown as Parameters<typeof createTask>[0],
       res,
     );
     expect(res.statusCode).toBe(201);
@@ -175,14 +193,20 @@ describe('multi-assignee tasks API (B1.2)', () => {
     const { createTask, updateTask } = await import('../src/controllers/tasks-controller.js');
     const createRes = makeRes();
     await createTask(
-      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [bob] }) as unknown as Parameters<typeof createTask>[0],
+      makeReq(
+        { eventId: String(eventId) },
+        { title: 't', assignee_user_ids: [bob] },
+      ) as unknown as Parameters<typeof createTask>[0],
       createRes,
     );
-    const taskId = ((createRes.body as { task: { id: number } }).task).id;
+    const taskId = (createRes.body as { task: { id: number } }).task.id;
 
     const updateRes = makeRes();
     await updateTask(
-      makeReq({ id: String(taskId), eventId: String(eventId) }, { assignee_user_ids: [carol, alice] }),
+      makeReq(
+        { id: String(taskId), eventId: String(eventId) },
+        { assignee_user_ids: [carol, alice] },
+      ),
       updateRes,
     );
     expect(updateRes.statusCode).toBe(200);
@@ -199,15 +223,55 @@ describe('multi-assignee tasks API (B1.2)', () => {
     expect(mirror?.assigned_user_id).toBe(carol);
   });
 
+  it('accepts Urgent priority on create and update task flows', async () => {
+    const { createTask, updateTask } = await import('../src/controllers/tasks-controller.js');
+
+    const createRes = makeRes();
+    await createTask(
+      makeReq(
+        { eventId: String(eventId) },
+        { title: 'critical path', priority: 'Urgent', assignee_user_ids: [bob] },
+      ) as unknown as Parameters<typeof createTask>[0],
+      createRes,
+    );
+
+    expect(createRes.statusCode).toBe(201);
+    const createdTask = (createRes.body as { task: { id: number; priority: string } }).task;
+    expect(createdTask.priority).toBe('Urgent');
+
+    const updateRes = makeRes();
+    await updateTask(
+      makeReq(
+        { id: String(createdTask.id), eventId: String(eventId) },
+        { priority: 'Urgent', assignee_user_ids: [carol] },
+      ),
+      updateRes,
+    );
+
+    expect(updateRes.statusCode).toBe(200);
+    expect((updateRes.body as { task: { priority: string } }).task.priority).toBe('Urgent');
+
+    const persisted = await testDb!.get<{ priority: string }>(
+      'SELECT priority FROM tasks WHERE id = $1',
+      [createdTask.id],
+    );
+    expect(persisted?.priority).toBe('Urgent');
+  });
+
   it('rejects assignee_user_ids containing a non-event-member', async () => {
     const { createTask } = await import('../src/controllers/tasks-controller.js');
     // Create a 4th user who is NOT a member of the event.
-    const stranger = (await testDb!.run(
-      `INSERT INTO users (email, display_name) VALUES ('mallory@example.com', 'Mallory') RETURNING id`,
-    )).lastID!;
+    const stranger = (
+      await testDb!.run(
+        `INSERT INTO users (email, display_name) VALUES ('mallory@example.com', 'Mallory') RETURNING id`,
+      )
+    ).lastID!;
     const res = makeRes();
     await createTask(
-      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [bob, stranger] }) as unknown as Parameters<typeof createTask>[0],
+      makeReq(
+        { eventId: String(eventId) },
+        { title: 't', assignee_user_ids: [bob, stranger] },
+      ) as unknown as Parameters<typeof createTask>[0],
       res,
     );
     expect(res.statusCode).toBe(400);
@@ -218,13 +282,17 @@ describe('multi-assignee tasks API (B1.2)', () => {
   });
 
   it('addAssignee + removeAssignee endpoints adjust the M:N set and promote next primary on primary removal', async () => {
-    const { createTask, addAssignee, removeAssignee } = await import('../src/controllers/tasks-controller.js');
+    const { createTask, addAssignee, removeAssignee } =
+      await import('../src/controllers/tasks-controller.js');
     const createRes = makeRes();
     await createTask(
-      makeReq({ eventId: String(eventId) }, { title: 't', assignee_user_ids: [alice] }) as unknown as Parameters<typeof createTask>[0],
+      makeReq(
+        { eventId: String(eventId) },
+        { title: 't', assignee_user_ids: [alice] },
+      ) as unknown as Parameters<typeof createTask>[0],
       createRes,
     );
-    const taskId = ((createRes.body as { task: { id: number } }).task).id;
+    const taskId = (createRes.body as { task: { id: number } }).task.id;
 
     // Add bob (secondary).
     const addRes = makeRes();

--- a/backend/src/controllers/task-templates-controller.ts
+++ b/backend/src/controllers/task-templates-controller.ts
@@ -65,8 +65,8 @@ export async function createTaskTemplate(req: Request, res: Response): Promise<R
   };
 
   if (!name?.trim()) return res.status(400).json({ error: 'Template name is required.' });
-  if (priority && !['Low', 'Medium', 'High'].includes(priority)) {
-    return res.status(400).json({ error: 'Priority must be Low, Medium, or High.' });
+  if (priority && !['Low', 'Medium', 'High', 'Urgent'].includes(priority)) {
+    return res.status(400).json({ error: 'Priority must be Low, Medium, High, or Urgent.' });
   }
   if (estimated_hours !== undefined && estimated_hours <= 0) {
     return res.status(400).json({ error: 'Estimated hours must be positive.' });
@@ -79,13 +79,19 @@ export async function createTaskTemplate(req: Request, res: Response): Promise<R
   const result = await db.run(
     `INSERT INTO task_templates (event_id, name, description, priority, estimated_hours, created_by)
      VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-    [eventId, name.trim(), description?.trim() ?? null, priority ?? 'Medium', estimated_hours ?? null, authReq.user.id],
+    [
+      eventId,
+      name.trim(),
+      description?.trim() ?? null,
+      priority ?? 'Medium',
+      estimated_hours ?? null,
+      authReq.user.id,
+    ],
   );
 
-  const template = await db.get<TaskTemplate>(
-    `SELECT * FROM task_templates WHERE id = $1`,
-    [result.lastID],
-  );
+  const template = await db.get<TaskTemplate>(`SELECT * FROM task_templates WHERE id = $1`, [
+    result.lastID,
+  ]);
   return res.status(201).json({ template });
 }
 
@@ -222,7 +228,13 @@ export async function addTimeEntry(req: Request, res: Response): Promise<Respons
   const result = await db.run(
     `INSERT INTO task_time_entries (task_id, user_id, hours_spent, notes, logged_at)
      VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-    [taskId, authReq.user.id, hours_spent, notes?.trim() ?? null, logged_at ?? new Date().toISOString().slice(0, 10)],
+    [
+      taskId,
+      authReq.user.id,
+      hours_spent,
+      notes?.trim() ?? null,
+      logged_at ?? new Date().toISOString().slice(0, 10),
+    ],
   );
 
   const entry = await db.get(

--- a/backend/src/controllers/tasks-controller.ts
+++ b/backend/src/controllers/tasks-controller.ts
@@ -9,14 +9,20 @@ interface AuthRequest extends Request {
 }
 
 const ALLOWED_STATUSES = new Set(['Pending', 'Complete', 'Completed', 'In Progress', 'Blocked']);
-const ALLOWED_PRIORITIES = new Set(['Low', 'Medium', 'High']);
+const ALLOWED_PRIORITIES = new Set(['Low', 'Medium', 'High', 'Urgent']);
 
 function normalizeTaskStatus(status?: string): string {
-  return status === 'Completed' ? 'Complete' : status ?? 'Pending';
+  return status === 'Completed' ? 'Complete' : (status ?? 'Pending');
 }
 
-async function getTaskTeamMemberIds(db: ReturnType<typeof getDatabase>, eventId: string): Promise<Set<number>> {
-  const rows = await db.all<{ user_id: number }>('SELECT user_id FROM event_members WHERE event_id = $1', [eventId]);
+async function getTaskTeamMemberIds(
+  db: ReturnType<typeof getDatabase>,
+  eventId: string,
+): Promise<Set<number>> {
+  const rows = await db.all<{ user_id: number }>(
+    'SELECT user_id FROM event_members WHERE event_id = $1',
+    [eventId],
+  );
   return new Set(rows.map((row) => Number(row.user_id)));
 }
 
@@ -92,10 +98,7 @@ async function replaceTaskAssignees(
     );
   }
   // Mirror primary to legacy column (or null when assignee set is empty).
-  await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [
-    userIds[0] ?? null,
-    taskId,
-  ]);
+  await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [userIds[0] ?? null, taskId]);
 }
 
 /** Single round-trip load of assignees for a set of task ids. Avoids N+1 in listTasks. */
@@ -174,8 +177,10 @@ export async function createTask(req: AuthRequest, res: Response): Promise<Respo
   const { title, notes, assignee_name, assigned_user_id, due_date, status, priority } = body;
 
   if (!title?.trim()) return res.status(400).json({ error: 'Task title is required.' });
-  if (status && !ALLOWED_STATUSES.has(status)) return res.status(400).json({ error: 'Invalid task status.' });
-  if (priority && !ALLOWED_PRIORITIES.has(priority)) return res.status(400).json({ error: 'Invalid priority.' });
+  if (status && !ALLOWED_STATUSES.has(status))
+    return res.status(400).json({ error: 'Invalid task status.' });
+  if (priority && !ALLOWED_PRIORITIES.has(priority))
+    return res.status(400).json({ error: 'Invalid priority.' });
 
   const db = getDatabase();
 
@@ -191,11 +196,17 @@ export async function createTask(req: AuthRequest, res: Response): Promise<Respo
     const parsed = await normaliseAssigneeIds(db, eventId, body.assignee_user_ids);
     if (!parsed.ok) return res.status(400).json({ error: parsed.error });
     assigneeIds = parsed.ids;
-  } else if (assigned_user_id !== undefined && assigned_user_id !== null && assigned_user_id !== '') {
+  } else if (
+    assigned_user_id !== undefined &&
+    assigned_user_id !== null &&
+    assigned_user_id !== ''
+  ) {
     const n = Number(assigned_user_id);
-    if (!Number.isInteger(n)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+    if (!Number.isInteger(n))
+      return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
     const teamMembers = await getTaskTeamMemberIds(db, eventId);
-    if (!teamMembers.has(n)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+    if (!teamMembers.has(n))
+      return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
     assigneeIds = [n];
   }
 
@@ -294,9 +305,11 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
       newAssigneeIds = [];
     } else {
       const n = Number(assigned_user_id);
-      if (!Number.isInteger(n)) return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
+      if (!Number.isInteger(n))
+        return res.status(400).json({ error: 'assigned_user_id must be a valid user id.' });
       const teamMembers = await getTaskTeamMemberIds(db, String(task.event_id));
-      if (!teamMembers.has(n)) return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
+      if (!teamMembers.has(n))
+        return res.status(400).json({ error: 'Assigned user must be a member of this event.' });
       newAssigneeIds = [n];
     }
   }
@@ -320,20 +333,35 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
     }
   }
 
-  if (title !== undefined) { fields.push('title = ?'); params.push(title.trim()); }
-  if (notes !== undefined) { fields.push('notes = ?'); params.push(notes.trim() || null); }
-  if (due_date !== undefined) { fields.push('due_date = ?'); params.push(due_date || null); }
+  if (title !== undefined) {
+    fields.push('title = ?');
+    params.push(title.trim());
+  }
+  if (notes !== undefined) {
+    fields.push('notes = ?');
+    params.push(notes.trim() || null);
+  }
+  if (due_date !== undefined) {
+    fields.push('due_date = ?');
+    params.push(due_date || null);
+  }
   if (status !== undefined) {
-    if (!ALLOWED_STATUSES.has(status)) return res.status(400).json({ error: 'Invalid task status.' });
+    if (!ALLOWED_STATUSES.has(status))
+      return res.status(400).json({ error: 'Invalid task status.' });
     fields.push('status = ?');
     params.push(normalizeTaskStatus(status));
   }
   if (priority !== undefined) {
-    if (!ALLOWED_PRIORITIES.has(priority)) return res.status(400).json({ error: 'Invalid priority.' });
+    if (!ALLOWED_PRIORITIES.has(priority))
+      return res.status(400).json({ error: 'Invalid priority.' });
     fields.push('priority = ?');
     params.push(priority);
   }
-  if (assignee_name !== undefined && assigned_user_id === undefined && body.assignee_user_ids === undefined) {
+  if (
+    assignee_name !== undefined &&
+    assigned_user_id === undefined &&
+    body.assignee_user_ids === undefined
+  ) {
     fields.push('assignee_name = ?');
     params.push(assignee_name.trim() || null);
   }
@@ -375,7 +403,7 @@ export async function updateTask(req: Request, res: Response): Promise<Response>
       String(task.event_id),
       authReq.user?.id ?? null,
       'task_completed',
-      `Task completed: ${(updated as Record<string, unknown> | null)?.['title'] as string ?? 'Unknown'}`,
+      `Task completed: ${((updated as Record<string, unknown> | null)?.['title'] as string) ?? 'Unknown'}`,
       `/events/${task.event_id as string}`,
     );
   }
@@ -410,7 +438,10 @@ export async function listAssignees(req: Request, res: Response): Promise<Respon
   const { eventId, taskId } = req.params;
   const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
-  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [
+    taskId,
+    eventId,
+  ]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
   const map = await loadAssigneesForTasks(db, [Number(taskId)]);
   return res.json({ assignees: map.get(Number(taskId)) ?? [] });
@@ -423,7 +454,10 @@ export async function addAssignee(req: Request, res: Response): Promise<Response
   const { eventId, taskId } = req.params;
   const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
-  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [
+    taskId,
+    eventId,
+  ]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
   const body = req.body as { user_id?: number | string; is_primary?: boolean };
@@ -473,10 +507,10 @@ export async function removeAssignee(req: Request, res: Response): Promise<Respo
   );
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
-  const removed = await db.run(
-    'DELETE FROM task_assignees WHERE task_id = ? AND user_id = ?',
-    [taskId, userId],
-  );
+  const removed = await db.run('DELETE FROM task_assignees WHERE task_id = ? AND user_id = ?', [
+    taskId,
+    userId,
+  ]);
   if (removed.changes === 0) {
     return res.status(404).json({ error: 'Assignee not found on this task.' });
   }
@@ -495,9 +529,14 @@ export async function removeAssignee(req: Request, res: Response): Promise<Respo
         nextPrimary.user_id,
         taskId,
       ]);
-      await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [nextPrimary.user_id, taskId]);
+      await db.run('UPDATE tasks SET assigned_user_id = ? WHERE id = ?', [
+        nextPrimary.user_id,
+        taskId,
+      ]);
     } else {
-      await db.run('UPDATE tasks SET assigned_user_id = NULL, assignee_name = NULL WHERE id = ?', [taskId]);
+      await db.run('UPDATE tasks SET assigned_user_id = NULL, assignee_name = NULL WHERE id = ?', [
+        taskId,
+      ]);
     }
   }
 
@@ -522,7 +561,10 @@ export async function listComments(req: Request, res: Response): Promise<Respons
   const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
 
-  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [
+    taskId,
+    eventId,
+  ]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
   const comments = await db.all(
@@ -547,7 +589,10 @@ export async function addComment(req: AuthRequest, res: Response): Promise<Respo
   const event = await requireEventAccess(req, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
 
-  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [
+    taskId,
+    eventId,
+  ]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
   const result = await db.run(
@@ -579,7 +624,10 @@ export async function addSubtask(req: Request, res: Response): Promise<Response>
   const event = await requireEventAccess(authReq, res, eventId, { allowMembers: true });
   if (!event) return res as Response;
 
-  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [taskId, eventId]);
+  const task = await db.get('SELECT id FROM tasks WHERE id = $1 AND event_id = $2', [
+    taskId,
+    eventId,
+  ]);
   if (!task) return res.status(404).json({ error: 'Task not found.' });
 
   const result = await db.run(

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -1288,7 +1288,7 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
       assigned_user_id INTEGER,
       due_date TEXT,
       status TEXT CHECK(status IN ('Pending', 'In Progress', 'Blocked', 'Complete')) DEFAULT 'Pending',
-      priority TEXT CHECK(priority IN ('Low', 'Medium', 'High')) DEFAULT 'Medium',
+      priority TEXT CHECK(priority IN ('Low', 'Medium', 'High', 'Urgent')) DEFAULT 'Medium',
       created_by INTEGER,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1568,6 +1568,10 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
   await db.exec(
     `ALTER TABLE tasks ADD COLUMN IF NOT EXISTS created_by INTEGER REFERENCES users(id) ON DELETE SET NULL`,
   );
+  await db.exec(`ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_priority_check`);
+  await db.exec(
+    `ALTER TABLE tasks ADD CONSTRAINT tasks_priority_check CHECK(priority IN ('Low', 'Medium', 'High', 'Urgent'))`,
+  );
 
   // ── Vendors schema drift fix ──────────────────────────────────────────────
   // Older DB had company_name/booking_status; current code expects name/status
@@ -1774,7 +1778,7 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
       event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
       name            TEXT NOT NULL,
       description     TEXT,
-      priority        TEXT CHECK(priority IN ('Low','Medium','High')) DEFAULT 'Medium',
+      priority        TEXT CHECK(priority IN ('Low','Medium','High','Urgent')) DEFAULT 'Medium',
       estimated_hours NUMERIC(5,2),
       created_by      INTEGER REFERENCES users(id) ON DELETE SET NULL,
       created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -1782,6 +1786,12 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
   `);
   await db.exec(
     `CREATE INDEX IF NOT EXISTS idx_task_templates_event_id ON task_templates(event_id)`,
+  );
+  await db.exec(
+    `ALTER TABLE task_templates DROP CONSTRAINT IF EXISTS task_templates_priority_check`,
+  );
+  await db.exec(
+    `ALTER TABLE task_templates ADD CONSTRAINT task_templates_priority_check CHECK(priority IN ('Low', 'Medium', 'High', 'Urgent'))`,
   );
 
   await db.exec(`

--- a/database/init.sql
+++ b/database/init.sql
@@ -242,7 +242,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   assigned_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
   due_date         TEXT,
   status           TEXT CHECK(status IN ('Pending', 'In Progress', 'Blocked', 'Complete')) DEFAULT 'Pending',
-  priority         TEXT CHECK(priority IN ('Low', 'Medium', 'High')) DEFAULT 'Medium',
+  priority         TEXT CHECK(priority IN ('Low', 'Medium', 'High', 'Urgent')) DEFAULT 'Medium',
   created_by       INTEGER REFERENCES users(id) ON DELETE SET NULL,
   created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -687,7 +687,7 @@ CREATE TABLE IF NOT EXISTS task_templates (
   event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
   name            TEXT NOT NULL,
   description     TEXT,
-  priority        TEXT CHECK(priority IN ('Low','Medium','High')) DEFAULT 'Medium',
+  priority        TEXT CHECK(priority IN ('Low','Medium','High','Urgent')) DEFAULT 'Medium',
   estimated_hours NUMERIC(5,2),
   created_by      INTEGER REFERENCES users(id) ON DELETE SET NULL,
   created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/database/migrations/v23-task-priority-urgent-780.sql
+++ b/database/migrations/v23-task-priority-urgent-780.sql
@@ -1,0 +1,12 @@
+-- =============================================================
+-- Migration: v23 Task Priority Urgent parity
+-- Task: #780
+-- =============================================================
+
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_priority_check;
+ALTER TABLE tasks ADD CONSTRAINT tasks_priority_check
+  CHECK (priority IN ('Low', 'Medium', 'High', 'Urgent'));
+
+ALTER TABLE task_templates DROP CONSTRAINT IF EXISTS task_templates_priority_check;
+ALTER TABLE task_templates ADD CONSTRAINT task_templates_priority_check
+  CHECK (priority IN ('Low', 'Medium', 'High', 'Urgent'));

--- a/frontend/src/components/events/event-detail-page.tsx
+++ b/frontend/src/components/events/event-detail-page.tsx
@@ -130,7 +130,7 @@ interface UserOption {
 }
 
 const TASK_STATUSES = ['Pending', 'In Progress', 'Blocked', 'Complete', 'Completed'];
-const TASK_PRIORITIES = ['Low', 'Medium', 'High'];
+const TASK_PRIORITIES = ['Low', 'Medium', 'High', 'Urgent'] as const;
 const RSVP_STATUSES = ['Pending', 'Going', 'Maybe', 'Not Going', 'Declined'];
 const RSVP_EXPORT_FORMAT = 'csv';
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
@@ -1334,6 +1334,18 @@ export default function EventDetailPage(): JSX.Element {
               >
                 {TASK_PRIORITIES.map((priority) => (
                   <MenuItem key={priority} value={priority}>
+                    <Chip
+                      label={priority}
+                      size="small"
+                      color={
+                        priority === 'Low' ? 'success' : priority === 'Medium' ? 'warning' : 'error'
+                      }
+                      sx={
+                        priority === 'Urgent'
+                          ? { mr: 1, bgcolor: 'error.dark', color: 'common.white', fontWeight: 700 }
+                          : { mr: 1 }
+                      }
+                    />
                     {priority}
                   </MenuItem>
                 ))}

--- a/frontend/src/components/tasks/task-card.tsx
+++ b/frontend/src/components/tasks/task-card.tsx
@@ -14,7 +14,24 @@ const PRIORITY_COLORS: Record<string, 'default' | 'success' | 'warning' | 'error
   Low: 'success',
   Medium: 'warning',
   High: 'error',
+  Urgent: 'error',
 };
+
+function getPriorityChipSx(priority: string): {
+  fontWeight?: number;
+  bgcolor?: string;
+  color?: string;
+} {
+  if (priority !== 'Urgent') {
+    return {};
+  }
+
+  return {
+    bgcolor: 'error.dark',
+    color: 'common.white',
+    fontWeight: 700,
+  };
+}
 
 function isOverdue(dueDate: string | null): boolean {
   if (!dueDate) return false;
@@ -56,11 +73,13 @@ export function TaskCard({ task, subtasks, onClick }: TaskCardProps): JSX.Elemen
         '&:hover': { boxShadow: 3 },
         borderLeft: '3px solid',
         borderLeftColor:
-          task.priority === 'High'
-            ? 'error.main'
-            : task.priority === 'Medium'
-              ? 'warning.main'
-              : 'success.main',
+          task.priority === 'Urgent'
+            ? 'error.dark'
+            : task.priority === 'High'
+              ? 'error.main'
+              : task.priority === 'Medium'
+                ? 'warning.main'
+                : 'success.main',
       }}
       role="button"
       tabIndex={0}
@@ -101,7 +120,7 @@ export function TaskCard({ task, subtasks, onClick }: TaskCardProps): JSX.Elemen
           label={task.priority}
           size="small"
           color={PRIORITY_COLORS[task.priority] ?? 'default'}
-          sx={{ height: 18, fontSize: '0.65rem' }}
+          sx={{ height: 18, fontSize: '0.65rem', ...getPriorityChipSx(task.priority) }}
         />
         {task.due_date && (
           <Typography

--- a/frontend/src/components/tasks/task-detail-drawer.tsx
+++ b/frontend/src/components/tasks/task-detail-drawer.tsx
@@ -37,13 +37,30 @@ import {
 } from '../../services/tasks-service';
 
 const STATUSES: TaskStatus[] = ['Pending', 'In Progress', 'Blocked', 'Complete'];
-const PRIORITIES: TaskPriority[] = ['Low', 'Medium', 'High'];
+const PRIORITIES: TaskPriority[] = ['Low', 'Medium', 'High', 'Urgent'];
 
 const PRIORITY_COLORS: Record<TaskPriority, 'success' | 'warning' | 'error'> = {
   Low: 'success',
   Medium: 'warning',
   High: 'error',
+  Urgent: 'error',
 };
+
+function getPriorityChipSx(priority: TaskPriority): {
+  fontWeight?: number;
+  bgcolor?: string;
+  color?: string;
+} {
+  if (priority !== 'Urgent') {
+    return {};
+  }
+
+  return {
+    bgcolor: 'error.dark',
+    color: 'common.white',
+    fontWeight: 700,
+  };
+}
 
 interface TaskDetailDrawerProps {
   open: boolean;
@@ -266,8 +283,8 @@ export function TaskDetailDrawer({
                     <Chip
                       label={p}
                       size="small"
-                      color={PRIORITY_COLORS[p as TaskPriority]}
-                      sx={{ mr: 1 }}
+                      color={PRIORITY_COLORS[p]}
+                      sx={{ mr: 1, ...getPriorityChipSx(p) }}
                     />
                     {p}
                   </MenuItem>

--- a/frontend/src/components/tasks/tasks-kanban-page.tsx
+++ b/frontend/src/components/tasks/tasks-kanban-page.tsx
@@ -12,6 +12,7 @@ import AddIcon from '@mui/icons-material/Add';
 import {
   Box,
   Button,
+  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
@@ -112,6 +113,26 @@ function AddTaskDialog({
     }
   }
 
+  function renderPriorityOption(option: TaskPriority): JSX.Element {
+    const urgent = option === 'Urgent';
+
+    return (
+      <MenuItem key={option} value={option}>
+        <Chip
+          label={option}
+          size="small"
+          color={option === 'Low' ? 'success' : option === 'Medium' ? 'warning' : 'error'}
+          sx={
+            urgent
+              ? { mr: 1, bgcolor: 'error.dark', color: 'common.white', fontWeight: 700 }
+              : { mr: 1 }
+          }
+        />
+        {option}
+      </MenuItem>
+    );
+  }
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle>Add Task</DialogTitle>
@@ -135,9 +156,7 @@ function AddTaskDialog({
               value={priority}
               onChange={(e: SelectChangeEvent) => setPriority(e.target.value as TaskPriority)}
             >
-              <MenuItem value="Low">Low</MenuItem>
-              <MenuItem value="Medium">Medium</MenuItem>
-              <MenuItem value="High">High</MenuItem>
+              {(['Low', 'Medium', 'High', 'Urgent'] as const).map(renderPriorityOption)}
             </Select>
           </FormControl>
           <FormControl size="small" fullWidth>

--- a/frontend/src/services/task-templates-service.ts
+++ b/frontend/src/services/task-templates-service.ts
@@ -9,7 +9,7 @@ export interface TaskTemplate {
   event_id: number;
   name: string;
   description: string | null;
-  priority: 'Low' | 'Medium' | 'High';
+  priority: 'Low' | 'Medium' | 'High' | 'Urgent';
   estimated_hours: number | null;
   created_by: number | null;
   created_at: string;
@@ -46,10 +46,7 @@ export async function createTaskTemplate(
   return data.template;
 }
 
-export async function deleteTaskTemplate(
-  eventId: number | string,
-  id: number,
-): Promise<void> {
+export async function deleteTaskTemplate(eventId: number | string, id: number): Promise<void> {
   await api.delete(`/api/events/${eventId}/task-templates/${id}`);
 }
 
@@ -58,7 +55,7 @@ export interface AppliedTask {
   event_id: number;
   title: string;
   description: string | null;
-  priority: 'Low' | 'Medium' | 'High';
+  priority: 'Low' | 'Medium' | 'High' | 'Urgent';
   estimated_hours: number | null;
   assignee_name: string | null;
   due_date: string | null;

--- a/frontend/src/services/tasks-service.ts
+++ b/frontend/src/services/tasks-service.ts
@@ -15,7 +15,7 @@ export type TaskStatus =
   | 'Complete'
   | 'Cancelled';
 
-export type TaskPriority = 'Low' | 'Medium' | 'High';
+export type TaskPriority = 'Low' | 'Medium' | 'High' | 'Urgent';
 
 export interface Task {
   id: number;
@@ -112,10 +112,7 @@ export async function updateTask(
   return data.task;
 }
 
-export async function deleteTask(
-  eventId: number | string,
-  taskId: number | string,
-): Promise<void> {
+export async function deleteTask(eventId: number | string, taskId: number | string): Promise<void> {
   await api.delete(`/api/events/${eventId}/tasks/${taskId}`);
 }
 
@@ -216,10 +213,10 @@ export async function updateTaskStatus(
   status: TaskStatus,
   options?: { cancelled_reason?: string; version?: number },
 ): Promise<Task> {
-  const data = await api.patch<{ task: Task }>(
-    `/api/events/${eventId}/tasks/${taskId}/status`,
-    { status, ...options },
-  );
+  const data = await api.patch<{ task: Task }>(`/api/events/${eventId}/tasks/${taskId}/status`, {
+    status,
+    ...options,
+  });
   return data.task;
 }
 
@@ -227,16 +224,18 @@ export async function verifyTaskCompletion(
   eventId: number | string,
   taskId: number | string,
 ): Promise<Task> {
-  const data = await api.post<{ task: Task }>(
-    `/api/events/${eventId}/tasks/${taskId}/verify`,
-  );
+  const data = await api.post<{ task: Task }>(`/api/events/${eventId}/tasks/${taskId}/verify`);
   return data.task;
 }
 
 // ── #605: Escalation policy ───────────────────────────────────────────────────
 
-export async function getEscalationPolicy(eventId: number | string): Promise<EscalationPolicy | null> {
-  const data = await api.get<{ policy: EscalationPolicy | null }>(`/api/events/${eventId}/escalation-policy`);
+export async function getEscalationPolicy(
+  eventId: number | string,
+): Promise<EscalationPolicy | null> {
+  const data = await api.get<{ policy: EscalationPolicy | null }>(
+    `/api/events/${eventId}/escalation-policy`,
+  );
   return data.policy;
 }
 

--- a/frontend/test/tasks-kanban.test.tsx
+++ b/frontend/test/tasks-kanban.test.tsx
@@ -163,7 +163,13 @@ describe('TasksKanbanPage', () => {
   });
 
   it('calls createTask when the add task form is submitted', async () => {
-    const newTask: Task = { ...mockTasks[0], id: 99, title: 'New Task', status: 'Pending' };
+    const newTask: Task = {
+      ...mockTasks[0],
+      id: 99,
+      title: 'New Task',
+      status: 'Pending',
+      priority: 'Urgent',
+    };
     vi.mocked(tasksService.createTask).mockResolvedValue(newTask);
 
     const user = userEvent.setup();
@@ -180,15 +186,34 @@ describe('TasksKanbanPage', () => {
     await user.clear(titleInput);
     await user.type(titleInput, 'New Task');
 
+    await user.click(within(dialog).getAllByRole('combobox')[0]);
+    await user.click(await screen.findByRole('option', { name: /urgent/i }));
+
     await user.click(within(dialog).getByRole('button', { name: 'Add' }));
 
     await waitFor(() => {
       expect(tasksService.createTask).toHaveBeenCalledWith(
         '42',
-        expect.objectContaining({ title: 'New Task', status: 'Pending' }),
+        expect.objectContaining({ title: 'New Task', status: 'Pending', priority: 'Urgent' }),
       );
     });
   }, 15000);
+
+  it('offers Urgent in the priority picker', async () => {
+    const user = userEvent.setup();
+    renderBoard();
+    await waitFor(() => {
+      expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+
+    const addButtons = screen.getAllByText('Add');
+    await user.click(addButtons[0]);
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getAllByRole('combobox')[0]);
+
+    expect(await screen.findByRole('option', { name: /urgent/i })).toBeTruthy();
+  });
 
   it('shows loading spinner initially', () => {
     vi.mocked(tasksService.listTasks).mockReturnValue(new Promise(() => undefined));


### PR DESCRIPTION
## Summary
- align task priority parity so `Urgent` is accepted end-to-end
- add migration to update `tasks` and `task_templates` priority constraints
- update backend validation, frontend pickers/visuals, and tests

## Validation
- `npm --prefix backend run typecheck`
- `npm --prefix backend test -- multi-assignee-tasks.test.ts`
- `npm --prefix frontend test -- tasks-kanban.test.tsx`
- `npm --prefix frontend run build`

Refs #763