### PR TITLE
chore(auth): [TASK] standardize local entra docker auth workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ TOKEN_HASH_SECRET=change-this-to-a-random-secret
 # ---- Refresh Token Encryption ----
 # AES-256 key encoded as base64 (32 raw bytes → 44 base64 chars).
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
-REFRESH_TOKEN_ENC_KEY=base64-encoded-32-byte-key-here
+REFRESH_TOKEN_ENC_KEY=
 
 # ---- CORS ----
 # Comma-separated list of allowed origins in production
@@ -63,7 +63,9 @@ EMAIL_WEBHOOK_SECRET=
 # Register an app in Azure Portal → App registrations to obtain the values below.
 # REQUIRED: Set AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET before deploying.
 ENTRA_AUTH_ENABLED=true
-ENTRA_MFA_REQUIRED=true
+# Local default: false to avoid blocking dev logins when tenant policies differ.
+# Set true in secure environments where MFA claim enforcement is mandatory.
+ENTRA_MFA_REQUIRED=false
 # #781 — UI affordance flag. When Entra is enabled, the login page hides the
 # email/password form by default. Set this to `true` to expose a "Use a local
 # account" disclosure that reveals the legacy credential fields. Note this
@@ -73,6 +75,8 @@ ENTRA_ALLOW_LOCAL_FALLBACK=false
 AZURE_TENANT_ID=your-tenant-id
 AZURE_CLIENT_ID=your-client-id
 AZURE_CLIENT_SECRET=your-client-secret
+# Set true when app registration is configured as Public Client (SPA flow)
+AZURE_PUBLIC_CLIENT=true
 # Redirect URI must match the one registered in Azure App Registration
 AZURE_REDIRECT_URI=http://localhost:8081/auth/callback
 # For CIAM tenants, set the full authority URL (ciamlogin.com).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ This repository is designed to teach:
    - [Release Process](docs/processes/release-process.md) - Deployment process
    - [Contributing Guidelines](CONTRIBUTING.md) - How to contribute
 
+5. **Bootstrap local auth environment (recommended for all devs)**
+
+   ```bash
+   ./scripts/bootstrap-dev.sh
+   ```
+
+   This ensures local `.env` contains valid auth secrets (including
+   `REFRESH_TOKEN_ENC_KEY`) and consistent Entra defaults.
+
 ### Running the Application
 
 Run the active root application:
@@ -87,6 +96,12 @@ Optional: run backend API in another terminal when working on backend training t
 ```bash
 docker compose up -d db
 cd backend && npm run dev
+```
+
+To validate local auth setup after startup:
+
+```bash
+./scripts/smoke-auth.sh
 ```
 
 Optional: run the separate `frontend/` training app surface if you specifically need it:

--- a/backend/src/config/entra.ts
+++ b/backend/src/config/entra.ts
@@ -1,7 +1,8 @@
 export interface EntraConfig {
   tenantId: string;
   clientId: string;
-  clientSecret: string;
+  clientSecret?: string;
+  publicClient: boolean;
   redirectUri: string;
   authority: string;
   jwksUri: string;
@@ -23,11 +24,12 @@ export function getEntraConfig(): EntraConfig {
   const tenantId = process.env.AZURE_TENANT_ID;
   const clientId = process.env.AZURE_CLIENT_ID;
   const clientSecret = process.env.AZURE_CLIENT_SECRET;
+  const publicClient = process.env.AZURE_PUBLIC_CLIENT === 'true';
 
-  if (!tenantId || !clientId || !clientSecret) {
+  if (!tenantId || !clientId || (!publicClient && !clientSecret)) {
     throw new Error(
       'Entra auth is enabled but missing required environment variables: ' +
-        'AZURE_TENANT_ID, AZURE_CLIENT_ID, and AZURE_CLIENT_SECRET must all be set.',
+        'AZURE_TENANT_ID and AZURE_CLIENT_ID must be set, and AZURE_CLIENT_SECRET is required unless AZURE_PUBLIC_CLIENT=true.',
     );
   }
 
@@ -40,7 +42,7 @@ export function getEntraConfig(): EntraConfig {
     `https://login.microsoftonline.com/${tenantId}`;
   const jwksUri = `${authority}/discovery/v2.0/keys`;
 
-  return { tenantId, clientId, clientSecret, redirectUri, authority, jwksUri };
+  return { tenantId, clientId, clientSecret, publicClient, redirectUri, authority, jwksUri };
 }
 
 /**

--- a/backend/src/controllers/entra-auth-controller.ts
+++ b/backend/src/controllers/entra-auth-controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import crypto from 'crypto';
+import { parse as parseCookies } from 'cookie';
 import {
   isEntraEnabled,
   getEntraConfig,
@@ -18,6 +19,22 @@ interface UserRow {
   email: string;
   role_id: number;
   entra_oid: string | null;
+}
+
+interface PendingEntraAuth {
+  codeVerifier: string;
+  createdAt: number;
+}
+
+const PENDING_ENTRA_TTL_MS = 10 * 60 * 1000;
+const pendingEntraAuth = new Map<string, PendingEntraAuth>();
+
+function prunePendingEntraAuth(now: number = Date.now()): void {
+  for (const [state, pending] of pendingEntraAuth.entries()) {
+    if (now - pending.createdAt > PENDING_ENTRA_TTL_MS) {
+      pendingEntraAuth.delete(state);
+    }
+  }
 }
 
 function tokenHasGroupOverage(claims: Record<string, unknown>): boolean {
@@ -79,6 +96,25 @@ export function getEntraStatus(_req: Request, res: Response): void {
   });
 }
 
+/**
+ * Provide SPA-specific Entra configuration for frontend token exchange.
+ * SPA clients must exchange the authorization code directly from the browser
+ * to avoid AADSTS9002327 ("tokens may only be redeemed via cross-origin requests").
+ */
+export function getSpaEntraConfig(_req: Request, res: Response): void {
+  if (!isEntraEnabled()) {
+    res.status(404).json({ error: 'Entra auth is not enabled.' });
+    return;
+  }
+
+  const config = getEntraConfig();
+  res.json({
+    clientId: config.clientId,
+    authority: config.authority,
+    redirectUri: config.redirectUri,
+  });
+}
+
 export function initiateEntraLogin(_req: Request, res: Response): void {
   if (!isEntraEnabled()) {
     res.status(404).json({ error: 'Entra auth is not enabled.' });
@@ -86,10 +122,13 @@ export function initiateEntraLogin(_req: Request, res: Response): void {
   }
 
   const config = getEntraConfig();
+  const redirectUri = config.redirectUri;
   const state = crypto.randomBytes(16).toString('hex');
   const nonce = crypto.randomBytes(16).toString('hex');
   const codeVerifier = crypto.randomBytes(32).toString('base64url');
   const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+  prunePendingEntraAuth();
+  pendingEntraAuth.set(state, { codeVerifier, createdAt: Date.now() });
 
   res.cookie('entra_state', state, {
     httpOnly: true,
@@ -108,7 +147,7 @@ export function initiateEntraLogin(_req: Request, res: Response): void {
   const params = new URLSearchParams({
     client_id: config.clientId,
     response_type: 'code',
-    redirect_uri: config.redirectUri,
+    redirect_uri: redirectUri,
     scope: 'openid profile email',
     state,
     nonce,
@@ -118,6 +157,52 @@ export function initiateEntraLogin(_req: Request, res: Response): void {
   });
 
   res.redirect(`${config.authority}/oauth2/v2.0/authorize?${params.toString()}`);
+}
+
+/**
+ * Endpoint for SPA clients: returns the initialization data needed for frontend-side token exchange.
+ * Returns the authorization URL, state, nonce, and code_verifier for storing in browser storage.
+ *
+ * SPA clients must initiate login via this endpoint to prepare PKCE parameters before
+ * generating the authorization URL.
+ */
+export function initiateSpaEntraLogin(_req: Request, res: Response): void {
+  if (!isEntraEnabled()) {
+    res.status(404).json({ error: 'Entra auth is not enabled.' });
+    return;
+  }
+
+  const config = getEntraConfig();
+  const redirectUri = config.redirectUri;
+  const state = crypto.randomBytes(16).toString('hex');
+  const nonce = crypto.randomBytes(16).toString('hex');
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+
+  prunePendingEntraAuth();
+  pendingEntraAuth.set(state, { codeVerifier, createdAt: Date.now() });
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    response_type: 'code',
+    redirect_uri: redirectUri,
+    scope: 'openid profile email',
+    state,
+    nonce,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    response_mode: 'query',
+  });
+
+  const authUrl = `${config.authority}/oauth2/v2.0/authorize?${params.toString()}`;
+
+  // Return auth data for frontend to store and use
+  res.json({
+    authUrl,
+    state,
+    nonce,
+    codeVerifier,
+  });
 }
 
 export async function handleEntraCallback(req: Request, res: Response): Promise<void> {
@@ -142,16 +227,36 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
   }
 
   const config = getEntraConfig();
+  const redirectUri = config.redirectUri;
   let idToken: string;
   let accessTokenForGraph: string | null = null;
 
+  // SPA Flow: Frontend provides pre-exchanged id_token (recommended for SPA clients)
   if (directIdToken) {
     idToken = directIdToken;
+    const accessToken = (req.body as { access_token?: string }).access_token;
+    accessTokenForGraph = typeof accessToken === 'string' ? accessToken : null;
   } else {
-    const expectedState = (req.cookies?.entra_state as string | undefined) ?? '';
-    const codeVerifier = (req.cookies?.entra_pkce_verifier as string | undefined) ?? '';
+    // Legacy Backend Flow: Backend exchanges code for token
+    // This is less secure for SPAs but maintained for backward compatibility
+    const parsedCookies = parseCookies(req.headers?.cookie ?? '');
+    const expectedStateFromCookie =
+      (req.cookies?.entra_state as string | undefined) ??
+      (parsedCookies.entra_state as string | undefined) ??
+      '';
+    const codeVerifierFromCookie =
+      (req.cookies?.entra_pkce_verifier as string | undefined) ??
+      (parsedCookies.entra_pkce_verifier as string | undefined) ??
+      '';
+    prunePendingEntraAuth();
+    const pending = state ? pendingEntraAuth.get(state) : undefined;
+    const hasPendingState = Boolean(state && pending);
+    const stateMatchesCookie = Boolean(
+      state && expectedStateFromCookie && state === expectedStateFromCookie,
+    );
+    const codeVerifier = codeVerifierFromCookie || pending?.codeVerifier || '';
 
-    if (!state || !expectedState || state !== expectedState) {
+    if (!state || (!stateMatchesCookie && !hasPendingState)) {
       res.status(401).json({ error: 'Invalid or missing Entra state.' });
       return;
     }
@@ -163,14 +268,18 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
       return;
     }
 
+    pendingEntraAuth.delete(state);
+
     const body = new URLSearchParams({
       client_id: config.clientId,
-      client_secret: config.clientSecret,
       code: code!,
       code_verifier: codeVerifier,
-      redirect_uri: config.redirectUri,
+      redirect_uri: redirectUri,
       grant_type: 'authorization_code',
     });
+    if (!config.publicClient && config.clientSecret) {
+      body.set('client_secret', config.clientSecret);
+    }
 
     const tokenRes = await fetch(`${config.authority}/oauth2/v2.0/token`, {
       method: 'POST',
@@ -180,9 +289,21 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
 
     if (!tokenRes.ok) {
       const err = (await tokenRes.json().catch(() => ({}))) as Record<string, unknown>;
+      const errorCode = typeof err.error === 'string' ? err.error : 'token_exchange_failed';
+      const errorDescription =
+        typeof err.error_description === 'string' ? err.error_description : undefined;
+      console.warn('[Entra] Token exchange failed', {
+        status: tokenRes.status,
+        errorCode,
+        errorDescription,
+      });
       res.clearCookie('entra_state');
       res.clearCookie('entra_pkce_verifier');
-      res.status(401).json({ error: 'Failed to exchange code for token.', details: err });
+      res.status(401).json({
+        error: 'Failed to exchange code for token.',
+        code: errorCode,
+        details: process.env.NODE_ENV === 'development' ? err : undefined,
+      });
       return;
     }
 
@@ -201,13 +322,21 @@ export async function handleEntraCallback(req: Request, res: Response): Promise<
   res.clearCookie('entra_state');
   res.clearCookie('entra_pkce_verifier');
 
-  const claims = await validateEntraIdToken(
-    idToken,
-    config.jwksUri,
-    config.clientId,
-    config.tenantId,
-    config.authority,
-  );
+  let claims: Awaited<ReturnType<typeof validateEntraIdToken>>;
+  try {
+    claims = await validateEntraIdToken(
+      idToken,
+      config.jwksUri,
+      config.clientId,
+      config.tenantId,
+      config.authority,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Token validation failed';
+    console.warn('[Entra] Token validation failed:', msg);
+    res.status(401).json({ error: msg });
+    return;
+  }
 
   // #568 — MFA enforcement: when ENTRA_MFA_REQUIRED=true the token's `amr`
   // claim MUST include 'mfa'. Azure AD sets this when MFA was completed.

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -217,6 +217,8 @@ router.post('/auth/login', createAuthLimiter(), authController.login);
 // ── Entra ID auth routes (#468, #469, #470) ────────────────────────────────
 // Feature-flagged: only functional when ENTRA_AUTH_ENABLED=true
 router.get('/auth/entra/config', entraAuthController.getEntraStatus);
+router.get('/auth/entra/spa-config', entraAuthController.getSpaEntraConfig);
+router.get('/auth/entra/init-spa', entraAuthController.initiateSpaEntraLogin);
 router.get('/auth/entra/login', entraAuthController.initiateEntraLogin);
 router.post('/auth/entra/callback', createAuthLimiter(), entraAuthController.handleEntraCallback);
 router.post('/auth/logout', authenticateToken, authController.logout);

--- a/backend/src/utils/auth-helpers.ts
+++ b/backend/src/utils/auth-helpers.ts
@@ -103,7 +103,13 @@ const _tokenHashSecret: Buffer = (() => {
 
 const _encKey: Buffer = (() => {
   const keyBase64 = process.env.REFRESH_TOKEN_ENC_KEY;
-  if (keyBase64) return Buffer.from(keyBase64, 'base64');
+  if (keyBase64) {
+    const decoded = Buffer.from(keyBase64, 'base64');
+    if (decoded.length !== 32) {
+      throw new Error('REFRESH_TOKEN_ENC_KEY must be base64-encoded 32 bytes for AES-256-GCM.');
+    }
+    return decoded;
+  }
   if (process.env.NODE_ENV === 'production') {
     throw new Error('REFRESH_TOKEN_ENC_KEY environment variable must be set in production');
   }

--- a/backend/src/utils/entra-token.ts
+++ b/backend/src/utils/entra-token.ts
@@ -136,6 +136,14 @@ export async function validateEntraIdToken(
     issuerTenant = tokenPayload.tid;
   }
 
+  // Log actual issuer from decoded token for debugging
+  const rawPayloadForLog = decoded.payload;
+  const actualIssuer =
+    typeof rawPayloadForLog === 'object' && rawPayloadForLog !== null
+      ? (rawPayloadForLog as Record<string, unknown>).iss
+      : undefined;
+  console.log('[Entra] Token issuer (iss):', actualIssuer);
+
   const validIssuers: [string, ...string[]] = [
     `https://login.microsoftonline.com/${issuerTenant}/v2.0`,
     `https://sts.windows.net/${issuerTenant}/`,
@@ -143,15 +151,45 @@ export async function validateEntraIdToken(
 
   // CIAM tenants use ciamlogin.com — include the authority-derived issuer
   // so the JWT verify step accepts tokens from custom CIAM domains.
+  // Include both with and without /v2.0 since CIAM issuers vary.
   if (authority && !isMicrosoftAuthority(authority)) {
-    validIssuers.push(`${authority.replace(/\/$/, '')}/v2.0`);
+    const base = authority.replace(/\/$/, '');
+    validIssuers.push(`${base}/v2.0`);
+    // Some CIAM tenants omit the /v2.0 suffix
+    validIssuers.push(base);
   }
 
+  // Some CIAM tokens use a tenant-hosted issuer format:
+  // https://{tenant-id}.ciamlogin.com/{tenant-id}/v2.0
+  if (tenantId.trim()) {
+    const ciamTenantHostBase = `https://${tenantId}.ciamlogin.com/${tenantId}`;
+    validIssuers.push(`${ciamTenantHostBase}/v2.0`);
+    validIssuers.push(ciamTenantHostBase);
+  }
+
+  console.log('[Entra] Valid issuers:', validIssuers);
+
+  // Verify signature + audience first, then perform normalized issuer checks
+  // because Entra/CIAM issuer strings can differ only by trailing slash.
   const verified = jwt.verify(idToken, pem, {
     algorithms: ['RS256'],
     audience: clientId,
-    issuer: validIssuers,
   });
+
+  const normalizeIssuer = (value: string): string => value.replace(/\/+$/, '');
+  const tokenIssuer =
+    typeof (verified as Record<string, unknown>).iss === 'string'
+      ? ((verified as Record<string, unknown>).iss as string)
+      : '';
+
+  const normalizedTokenIssuer = normalizeIssuer(tokenIssuer);
+  const normalizedExpectedIssuers = [...new Set(validIssuers.map(normalizeIssuer))];
+
+  if (!normalizedExpectedIssuers.includes(normalizedTokenIssuer)) {
+    throw new Error(
+      `jwt issuer invalid. expected: ${validIssuers.join(',')}; actual: ${tokenIssuer || '(missing iss)'}`,
+    );
+  }
 
   return verified as unknown as EntraTokenClaims;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,10 +92,12 @@ services:
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:${FRONTEND_PORT:-8081},http://localhost}
       - ENTRA_AUTH_ENABLED=${ENTRA_AUTH_ENABLED:-true}
       - ENTRA_MFA_REQUIRED=${ENTRA_MFA_REQUIRED:-true}
+      - ENTRA_ALLOW_LOCAL_FALLBACK=${ENTRA_ALLOW_LOCAL_FALLBACK:-false}
       - AZURE_TENANT_ID=${AZURE_TENANT_ID:-}
       - AZURE_AUTHORITY=${AZURE_AUTHORITY:-}
       - AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-}
       - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET:-}
+      - AZURE_PUBLIC_CLIENT=${AZURE_PUBLIC_CLIENT:-false}
       - AZURE_REDIRECT_URI=${AZURE_REDIRECT_URI:-http://localhost:8081/auth/callback}
       - ENTRA_GROUP_ADMINS=${ENTRA_GROUP_ADMINS:-}
       - ENTRA_GROUP_ORGANIZERS=${ENTRA_GROUP_ORGANIZERS:-}
@@ -166,7 +168,7 @@ services:
       - wal-archive:/var/lib/postgresql/wal_archive
     entrypoint: >
       sh -c "
-        apk add --no-cache dcron find &&
+        apk add --no-cache dcron &&
         echo '0 * * * * find /var/lib/postgresql/wal_archive -type f -mtime +14 -delete' > /etc/crontabs/root &&
         crond -f
       "

--- a/frontend/src/components/auth/entra-callback.tsx
+++ b/frontend/src/components/auth/entra-callback.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Box, CircularProgress, Alert, Typography } from '@mui/material';
-import { api, setToken } from '../../lib/api-client';
 import { useAuth } from '../../contexts/auth-context';
+import { exchangeCodeAndCreateSession } from '../../utils/entra-spa-flow';
 
 export function EntraCallbackPage(): JSX.Element {
   const [searchParams] = useSearchParams();
@@ -27,21 +27,28 @@ export function EntraCallbackPage(): JSX.Element {
       return;
     }
 
-    if (!code) {
-      setError('No authorization code received from Azure.');
+    if (!code || !state) {
+      setError('No authorization code or state received from Azure.');
       return;
     }
 
     (async () => {
       try {
-        const data = await api.post<{ accessToken?: string; user?: unknown }>(
-          '/api/auth/entra/callback',
-          { code, state },
-        );
-        if (data?.accessToken) setToken(data.accessToken as string);
-        navigate('/dashboard', { replace: true });
+        // Exchange code for tokens using SPA flow (frontend handles token exchange)
+        const result = await exchangeCodeAndCreateSession({ code, state });
+
+        if (result.success) {
+          navigate('/dashboard', { replace: true });
+        } else {
+          // Display error with code if available
+          const errorMsg: string = result.code
+            ? `${result.error ?? 'Unknown error'} (${result.code})`
+            : (result.error ?? 'Entra authentication failed.');
+          setError(errorMsg);
+        }
       } catch (err) {
-        setError((err as Error).message ?? 'Entra authentication failed.');
+        const errorMsg = err instanceof Error ? err.message : 'Entra authentication failed.';
+        setError(errorMsg);
       }
     })();
   }, [searchParams, navigate, loadCurrentUser]);

--- a/frontend/src/components/login-form/login-form.tsx
+++ b/frontend/src/components/login-form/login-form.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useAuth } from '../../contexts/auth-context';
 import { ApiError, api } from '../../lib/api-client';
+import { initiateSpaEntraLogin } from '../../utils/entra-spa-flow';
 
 interface EntraConfigResponse {
   enabled: boolean;
@@ -153,11 +154,21 @@ export function LoginForm({ onForgotPassword, onLogin, onRegister }: LoginFormPr
     }
   }
 
+  async function handleEntraLogin(): Promise<void> {
+    try {
+      await initiateSpaEntraLogin();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to initiate sign-in with Microsoft',
+      );
+    }
+  }
+
   const entraButton = entraEnabled ? (
     <Button
       variant="contained"
       fullWidth
-      href="/api/auth/entra/login"
+      onClick={handleEntraLogin}
       aria-label="Sign in with Microsoft"
       data-testid="entra-sign-in"
       sx={{ py: 1.5, fontWeight: 600, textTransform: 'none' }}

--- a/frontend/src/utils/entra-spa-flow.ts
+++ b/frontend/src/utils/entra-spa-flow.ts
@@ -1,0 +1,224 @@
+/**
+ * Entra SPA OAuth2 + PKCE token exchange utility.
+ * Handles the frontend-side token exchange for Single-Page Application (SPA) clients.
+ *
+ * Azure requires SPA clients to exchange the authorization code directly from the browser,
+ * not from a backend server (AADSTS9002327).
+ */
+import { api } from '../lib/api-client';
+
+interface StoredEntraState {
+  state: string;
+  codeVerifier: string;
+  nonce: string;
+}
+
+const ENTRA_STATE_STORAGE_KEY = 'entra_auth_state';
+
+/**
+ * Store Entra authentication state in sessionStorage
+ */
+function storeEntraAuthState(state: StoredEntraState): void {
+  try {
+    sessionStorage.setItem(ENTRA_STATE_STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.error('[Entra SPA] Failed to store auth state:', error);
+  }
+}
+
+/**
+ * Retrieve and clear stored Entra authentication state
+ */
+function retrieveAndClearEntraAuthState(): StoredEntraState | null {
+  try {
+    const stored = sessionStorage.getItem(ENTRA_STATE_STORAGE_KEY);
+    sessionStorage.removeItem(ENTRA_STATE_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : null;
+  } catch (error) {
+    console.error('[Entra SPA] Failed to retrieve auth state:', error);
+    return null;
+  }
+}
+
+interface TokenExchangeRequest {
+  code: string;
+  codeVerifier: string;
+  clientId: string;
+  redirectUri: string;
+  authority: string;
+}
+
+interface TokenExchangeResponse {
+  access_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * Exchange authorization code for tokens directly from the browser (SPA flow).
+ * This is required for Azure SPA clients — the code exchange must happen via cross-origin request.
+ */
+export async function exchangeCodeForToken(
+  params: TokenExchangeRequest,
+): Promise<TokenExchangeResponse> {
+  const { code, codeVerifier, clientId, redirectUri, authority } = params;
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    code,
+    code_verifier: codeVerifier,
+    redirect_uri: redirectUri,
+    grant_type: 'authorization_code',
+    // SPA clients don't send client_secret
+  });
+
+  try {
+    const response = await fetch(`${authority}/oauth2/v2.0/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+      return {
+        error: String(errorData.error || 'token_exchange_failed'),
+        error_description: String(errorData.error_description || 'Token exchange failed'),
+      };
+    }
+
+    const data = (await response.json()) as TokenExchangeResponse;
+    return data;
+  } catch (error) {
+    return {
+      error: 'fetch_failed',
+      error_description: error instanceof Error ? error.message : 'Failed to exchange code',
+    };
+  }
+}
+
+interface ExchangeCallbackParams {
+  code: string;
+  state: string;
+}
+
+/**
+ * Handle callback from Azure: exchange code for tokens and send to backend.
+ * Call this from the Entra callback page after Azure redirects back with the code.
+ */
+export async function exchangeCodeAndCreateSession(
+  params: ExchangeCallbackParams,
+): Promise<{ success: boolean; error?: string; code?: string }> {
+  const { code, state } = params;
+
+  // Retrieve stored auth state from session
+  const storedState = retrieveAndClearEntraAuthState();
+  if (!storedState) {
+    return {
+      success: false,
+      error: 'Authentication state not found. Please restart the login process.',
+    };
+  }
+
+  // Validate state parameter
+  if (!state || state !== storedState.state) {
+    return {
+      success: false,
+      error: 'State validation failed. Possible CSRF attack.',
+    };
+  }
+
+  // Fetch Entra config to get token endpoint details
+  let authState: { clientId: string; authority: string; redirectUri: string } | null = null;
+  try {
+    authState = await api.get('/api/auth/entra/spa-config');
+  } catch (error) {
+    console.error('[Entra SPA] Failed to fetch auth state:', error);
+  }
+
+  if (!authState) {
+    return {
+      success: false,
+      error: 'Failed to retrieve authentication configuration.',
+    };
+  }
+
+  // Exchange code for tokens directly from browser
+  const tokenResult = await exchangeCodeForToken({
+    code,
+    codeVerifier: storedState.codeVerifier,
+    clientId: authState.clientId,
+    redirectUri: authState.redirectUri,
+    authority: authState.authority,
+  });
+
+  if (tokenResult.error) {
+    return {
+      success: false,
+      error: tokenResult.error_description || tokenResult.error,
+      code: tokenResult.error,
+    };
+  }
+
+  if (!tokenResult.id_token) {
+    return {
+      success: false,
+      error: 'No ID token received from Azure.',
+    };
+  }
+
+  // Send tokens to backend to create session (use api.post to include CSRF token)
+  try {
+    await api.post('/api/auth/entra/callback', {
+      id_token: tokenResult.id_token,
+      access_token: tokenResult.access_token,
+    });
+
+    return { success: true };
+  } catch (error) {
+    const err = error as { message?: string; code?: string };
+    return {
+      success: false,
+      error: err.message ?? 'Failed to create session',
+      code: err.code,
+    };
+  }
+}
+
+/**
+ * Initialize SPA Entra login: get authorization URL and PKCE parameters
+ * Stores PKCE verifier in sessionStorage for later use during callback
+ */
+export async function initiateSpaEntraLogin(): Promise<void> {
+  try {
+    const response = await fetch('/api/auth/entra/init-spa');
+    if (!response.ok) {
+      throw new Error('Failed to initialize Entra login');
+    }
+
+    const data = (await response.json()) as {
+      authUrl: string;
+      state: string;
+      nonce: string;
+      codeVerifier: string;
+    };
+
+    // Store state, nonce, and code verifier in sessionStorage
+    storeEntraAuthState({
+      state: data.state,
+      codeVerifier: data.codeVerifier,
+      nonce: data.nonce,
+    });
+
+    // Redirect to Azure authorization endpoint
+    window.location.href = data.authUrl;
+  } catch (error) {
+    console.error('[Entra SPA] Failed to initiate login:', error);
+    throw error;
+  }
+}

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_EXAMPLE="${ROOT_DIR}/.env.example"
+ENV_FILE="${ROOT_DIR}/.env"
+
+if [[ ! -f "${ENV_EXAMPLE}" ]]; then
+  echo "Error: ${ENV_EXAMPLE} not found"
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  cp "${ENV_EXAMPLE}" "${ENV_FILE}"
+  echo "Created .env from .env.example"
+fi
+
+set_or_replace() {
+  local key="$1"
+  local value="$2"
+  if grep -q "^${key}=" "${ENV_FILE}"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "${ENV_FILE}"
+  else
+    printf "%s=%s\n" "${key}" "${value}" >> "${ENV_FILE}"
+  fi
+}
+
+get_value() {
+  local key="$1"
+  local value
+  value="$(grep -E "^${key}=" "${ENV_FILE}" | head -1 | cut -d'=' -f2- || true)"
+  printf "%s" "$value"
+}
+
+ensure_hex_secret() {
+  local key="$1"
+  local current
+  current="$(get_value "$key")"
+  if [[ -z "$current" || "$current" == change-* || "$current" == your-* ]]; then
+    set_or_replace "$key" "$(openssl rand -hex 32)"
+    echo "Generated ${key}"
+  fi
+}
+
+ensure_base64_32b() {
+  local key="$1"
+  local current decoded_len
+  current="$(get_value "$key")"
+
+  if [[ -n "$current" ]]; then
+    decoded_len="$(printf "%s" "$current" | base64 -d 2>/dev/null | wc -c | tr -d ' ')"
+  else
+    decoded_len="0"
+  fi
+
+  if [[ "$decoded_len" != "32" ]]; then
+    set_or_replace "$key" "$(openssl rand -base64 32 | tr -d '\n')"
+    echo "Generated ${key} (32-byte base64)"
+  fi
+}
+
+ensure_hex_secret "JWT_SECRET"
+ensure_hex_secret "TOKEN_HASH_SECRET"
+ensure_base64_32b "REFRESH_TOKEN_ENC_KEY"
+
+# Dev defaults for consistency across machines
+set_or_replace "ENTRA_MFA_REQUIRED" "false"
+set_or_replace "AZURE_PUBLIC_CLIENT" "true"
+
+echo "Bootstrap complete."
+echo "Next: docker compose up -d --build"

--- a/scripts/smoke-auth.sh
+++ b/scripts/smoke-auth.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8081}"
+
+check() {
+  local name="$1"
+  local url="$2"
+  local expected_prefix="$3"
+
+  local response
+  response="$(curl -sS "$url")"
+  if [[ "$response" == $expected_prefix* ]]; then
+    echo "[PASS] $name"
+  else
+    echo "[FAIL] $name"
+    echo "  URL: $url"
+    echo "  Response: $response"
+    exit 1
+  fi
+}
+
+check "Entra config endpoint" "${BASE_URL}/api/auth/entra/config" "{"
+check "CSRF token endpoint" "${BASE_URL}/api/csrf-token" "{"
+check "Entra SPA init endpoint" "${BASE_URL}/api/auth/entra/init-spa" "{"
+
+echo "All auth smoke checks passed."


### PR DESCRIPTION
## Summary
Standardizes local Entra + Docker auth setup so all developers can run the same workflow and avoid machine-specific auth failures.

## Linked Work Items
- Theme: #903
- User Story: #904
- Task: #901

Closes #901

## What Changed
- Added SPA-compatible Entra callback flow and supporting endpoints
- Added robust Entra issuer validation for CIAM issuer variants
- Added explicit validation for `REFRESH_TOKEN_ENC_KEY` length (32-byte base64)
- Added `scripts/bootstrap-dev.sh` to generate valid local auth secrets and defaults
- Added `scripts/smoke-auth.sh` to quickly validate auth endpoints locally
- Updated `.env.example` defaults/guidance for team consistency
- Updated `README.md` with standardized bootstrap + smoke-check steps

## Team Runbook (for all developers)
1. Pull latest `develop`
2. Run `./scripts/bootstrap-dev.sh`
3. Recreate local env from `.env.example` if needed
4. Start services with `docker compose up -d --build`
5. Validate with `./scripts/smoke-auth.sh`

## Validation Done
- `./scripts/smoke-auth.sh` passes
- Backend starts healthy after rebuild
- Commit is authored by `SmitRAmoliya`
