### PR TITLE
fix(events): require event_time in modal and fix budget comparison query (#901)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Task #901 — Event creation + budget comparison stability fixes**: Added required `event_time` input/validation to the Events list modal create/edit flow (`frontend/src/components/events/events-page.tsx`) so API `POST /api/events` requests always include valid `HH:MM` values. Also fixed SQL placeholder compatibility in backend similar-budget comparison prefilter query (`backend/src/controllers/budget-controller.ts`) to prevent runtime failures that surfaced as `Failed to compare budget data across similar events` (#901).
+
 - **Task #776 — Add `/api/health` TRD-compatible alias**: Backend now serves `GET /api/health` as an alias of `GET /health` using a shared handler so both endpoints always return identical payload and status. In-code OpenAPI definition now documents both routes, and smoke coverage in `backend/__tests__/health-endpoints.test.ts` asserts both endpoints return `200` and matching response bodies (#776).
 
 ### Added (Track E — Performance & Observability)

--- a/backend/src/controllers/budget-controller.ts
+++ b/backend/src/controllers/budget-controller.ts
@@ -402,9 +402,9 @@ export async function compareSimilarEvents(req: AuthRequest, res: Response): Pro
       (comparisonFilters.minCapacity !== null && comparisonFilters.maxCapacity !== null),
     );
     const adminFilterSql = hasAdminPrefilter
-      ? `AND ((? <> '' AND lower(COALESCE(event_type, '')) = ?)
-             OR (? <> '' AND lower(location) = ?)
-             OR (?::integer IS NOT NULL AND ?::integer IS NOT NULL AND capacity BETWEEN ? AND ?))`
+      ? `AND (($2 <> '' AND lower(COALESCE(event_type, '')) = $3)
+             OR ($4 <> '' AND lower(location) = $5)
+             OR ($6::integer IS NOT NULL AND $7::integer IS NOT NULL AND capacity BETWEEN $8 AND $9))`
       : '';
 
     const candidateEvents =

--- a/frontend/src/components/events/events-page.tsx
+++ b/frontend/src/components/events/events-page.tsx
@@ -86,6 +86,7 @@ interface PlannerEvent extends Omit<
     | 'latitude'
     | 'longitude'
     | 'waitlist_enabled'
+    | 'event_time'
     | 'going_count'
     | 'pending_count'
   >,
@@ -118,6 +119,7 @@ interface EventForm {
   description: string;
   location: string;
   date: string;
+  event_time: string;
   capacity: string;
   status: string;
   latitude: string;
@@ -132,6 +134,7 @@ const EMPTY_FORM: EventForm = {
   description: '',
   location: '',
   date: '',
+  event_time: '',
   capacity: '',
   status: 'Draft',
   latitude: '',
@@ -518,6 +521,7 @@ export default function EventsPage({
       description: '',
       location: event.location ?? '',
       date: event.date,
+      event_time: event.event_time ?? '',
       capacity: event.capacity == null ? '' : String(event.capacity),
       status: event.status,
       latitude: event.latitude == null ? '' : String(event.latitude),
@@ -541,6 +545,14 @@ export default function EventsPage({
       setSaveError('Event Date is required.');
       return;
     }
+    if (!form.event_time) {
+      setSaveError('Event time is required (HH:MM).');
+      return;
+    }
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(form.event_time)) {
+      setSaveError('Event time must be in HH:MM format (e.g. 09:00, 14:30).');
+      return;
+    }
     setSaving(true);
     try {
       const payload = {
@@ -548,6 +560,7 @@ export default function EventsPage({
         description: form.description,
         location: form.location,
         date: form.date,
+        event_time: form.event_time,
         capacity: form.capacity ? Number(form.capacity) : null,
         status: form.status,
         latitude: form.latitude === '' ? null : Number(form.latitude),
@@ -1435,6 +1448,17 @@ export default function EventsPage({
                 required
                 fullWidth
                 InputLabelProps={{ shrink: true }}
+              />
+              <TextField
+                label="Event time"
+                type="time"
+                value={form.event_time}
+                onChange={handleField('event_time')}
+                fullWidth
+                required
+                InputLabelProps={{ shrink: true }}
+                inputProps={{ step: 300 }}
+                helperText="Start time (required)"
               />
               <TextField
                 label="Status"

--- a/frontend/src/services/events-service.ts
+++ b/frontend/src/services/events-service.ts
@@ -36,6 +36,8 @@ export interface Event {
   is_public: boolean;
   rsvp_deadline: string | null;
   tags: string | null;
+  /** Story #664 — required event start time (HH:MM) for new events */
+  event_time?: string | null;
   /** Story #414 — map-backed location */
   latitude?: number | null;
   longitude?: number | null;


### PR DESCRIPTION
## Summary
- add required `event_time` input/validation to Events page modal create/edit flow
- include `event_time` in create/update payload from modal
- fix backend similar-budget query placeholder mismatch that caused 500 errors
- add changelog unreleased entry

## Validation
- `cd frontend && npm run build`
- `cd backend && npm run typecheck`
- `cd backend && npm test -- __tests__/event-time-field.test.ts __tests__/budget-comparison.test.ts`

## Work Item Linkage
- References #901
