### PR TITLE
fix(events): event CRUD implementation - create/update/delete fixes #911

### DIFF
--- a/backend/__tests__/event-time-field.test.ts
+++ b/backend/__tests__/event-time-field.test.ts
@@ -197,6 +197,26 @@ describe('createEvent — event_time validation', () => {
     expect(insertParams).toContain('09:30');
   });
 
+  it('accepts event_date as a compatibility alias on create', async () => {
+    const returnedEvent = { ...BASE_EVENT, event_time: '09:30' };
+    mockDb.run.mockResolvedValue({ lastID: 42 });
+    mockDb.get.mockResolvedValueOnce(returnedEvent);
+
+    const req = makeCreateReq({
+      title: 'Alias Festival',
+      event_date: FUTURE_DATE,
+      location: 'City Park',
+      event_time: '09:30',
+    });
+    const res = makeRes();
+
+    await createEvent(req, res as unknown as import('express').Response);
+
+    expect(res.statusCode).toBe(201);
+    const insertCall = mockDb.run.mock.calls[0] as [string, unknown[]];
+    expect(insertCall[1]).toContain(FUTURE_DATE);
+  });
+
   it('accepts midnight (00:00) as a valid event_time', async () => {
     const returnedEvent = { ...BASE_EVENT, event_time: '00:00' };
     mockDb.run.mockResolvedValue({ lastID: 42 });
@@ -290,6 +310,22 @@ describe('updateEvent — event_time validation', () => {
     expect(res.statusCode).toBe(200);
     const updateCall = mockDb.run.mock.calls[0] as [string, unknown[]];
     expect(updateCall[1]).toContain('18:30');
+  });
+
+  it('accepts event_date as a compatibility alias on update', async () => {
+    mockDb.get
+      .mockResolvedValueOnce(BASE_EVENT)
+      .mockResolvedValueOnce({ ...BASE_EVENT, event_time: '18:30' });
+    mockDb.run.mockResolvedValue({});
+
+    const req = makeUpdateReq('42', { event_date: FUTURE_DATE, event_time: '18:30' });
+    const res = makeRes();
+
+    await updateEvent(req, res as unknown as import('express').Response);
+
+    expect(res.statusCode).toBe(200);
+    const updateCall = mockDb.run.mock.calls[0] as [string, unknown[]];
+    expect(updateCall[1]).toContain(FUTURE_DATE);
   });
 });
 

--- a/backend/src/controllers/event-controller.ts
+++ b/backend/src/controllers/event-controller.ts
@@ -375,8 +375,9 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
 
     const {
       title,
-      // support both 'date' and 'start_date' as field name
+      // support both 'date', 'event_date', and 'start_date' as field name
       date: _date,
+      event_date,
       start_date,
       // support both 'location' and 'venue_name' as field name
       location: _location,
@@ -393,7 +394,7 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
       event_time,
     } = req.body as EventData & { start_date?: string; venue_name?: string };
 
-    const date = _date || start_date;
+    const date = _date || event_date || start_date;
     const location = _location || venue_name;
 
     // Validation
@@ -527,6 +528,7 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
     const {
       title,
       date: _date,
+      event_date,
       start_date,
       location: _location,
       venue_name,
@@ -546,7 +548,7 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
       event_time,
     } = req.body as EventData & { start_date?: string; venue_name?: string };
 
-    const date = _date || start_date;
+    const date = _date || event_date || start_date;
     const location = _location || venue_name;
 
     // Check if event exists

--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -1216,6 +1216,11 @@ async function runMigrations(db: DatabaseAdapter): Promise<void> {
   await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS tags TEXT`);
   await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS capacity INTEGER`);
   await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP`);
+  await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS latitude DOUBLE PRECISION`);
+  await db.exec(`ALTER TABLE events ADD COLUMN IF NOT EXISTS longitude DOUBLE PRECISION`);
+  await db.exec(
+    `ALTER TABLE events ADD COLUMN IF NOT EXISTS waitlist_enabled BOOLEAN DEFAULT FALSE`,
+  );
 
   // ── Idempotent TZ-fixup for high-risk expiry/deadline columns (#664) ────
   // Some installations created these columns as plain TIMESTAMP before the

--- a/frontend/src/components/events/event-form-page.tsx
+++ b/frontend/src/components/events/event-form-page.tsx
@@ -123,7 +123,7 @@ export default function EventFormPage(): JSX.Element {
         description: form.description.trim() || null,
         event_type: form.event_type,
         status: form.status,
-        date: form.date,
+        event_date: form.date,
         event_time: form.event_time,
         location: form.location.trim(),
         capacity: form.capacity ? Number(form.capacity) : null,

--- a/frontend/src/components/events/events-page.tsx
+++ b/frontend/src/components/events/events-page.tsx
@@ -559,7 +559,7 @@ export default function EventsPage({
         title: form.title,
         description: form.description,
         location: form.location,
-        date: form.date,
+        event_date: form.date,
         event_time: form.event_time,
         capacity: form.capacity ? Number(form.capacity) : null,
         status: form.status,

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -35,8 +35,8 @@ export function useEvents(filters?: Record<string, unknown>) {
       const params = filters
         ? '?' + new URLSearchParams(filters as Record<string, string>).toString()
         : '';
-      const data = await api.get<EventDetail[]>(`/events${params}`);
-      return data;
+      const data = await api.get<{ events: EventDetail[] }>(`/api/events${params}`);
+      return data.events ?? [];
     },
   });
 }
@@ -44,7 +44,10 @@ export function useEvents(filters?: Record<string, unknown>) {
 export function useEvent(id: number) {
   return useQuery({
     queryKey: EVENT_QUERY_KEYS.detail(id),
-    queryFn: () => api.get<EventDetail>(`/events/${id}`),
+    queryFn: async () => {
+      const data = await api.get<{ event: EventDetail }>(`/api/events/${id}`);
+      return data.event;
+    },
     enabled: id > 0,
   });
 }
@@ -52,7 +55,11 @@ export function useEvent(id: number) {
 export function useCreateEvent() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (payload: Partial<EventDetail>) => api.post<EventDetail>('/events', payload),
+    mutationFn: (payload: Partial<EventDetail> & { date?: string; event_date?: string }) =>
+      api.post<EventDetail>('/api/events', {
+        ...payload,
+        event_date: payload.event_date ?? payload.date,
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: EVENT_QUERY_KEYS.all });
     },
@@ -62,7 +69,11 @@ export function useCreateEvent() {
 export function useUpdateEvent(id: number) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (payload: Partial<EventDetail>) => api.patch<EventDetail>(`/events/${id}`, payload),
+    mutationFn: (payload: Partial<EventDetail> & { date?: string; event_date?: string }) =>
+      api.patch<EventDetail>(`/api/events/${id}`, {
+        ...payload,
+        event_date: payload.event_date ?? payload.date,
+      }),
     onSuccess: (updated) => {
       queryClient.setQueryData(EVENT_QUERY_KEYS.detail(id), updated);
       queryClient.invalidateQueries({ queryKey: EVENT_QUERY_KEYS.all });
@@ -73,7 +84,7 @@ export function useUpdateEvent(id: number) {
 export function useDeleteEvent() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (id: number) => api.delete(`/events/${id}`),
+    mutationFn: (id: number) => api.delete(`/api/events/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: EVENT_QUERY_KEYS.all });
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,18 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+      },
+      '/health': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
Fixes event CRUD operations that were failing due to payload field mismatch and missing database columns.

## Changes
- **Backend**: Event controller now accepts `event_date` alias alongside `date` and `start_date`
- **Database**: Added missing `latitude`, `longitude`, `waitlist_enabled` column migrations
- **Frontend**: Event forms and hooks aligned to use `event_date` field and `/api/events` endpoint
- **Tests**: Added event_date alias compatibility tests
- **Dev**: Added API proxy to root vite config for local development

## Validation
- All event CRUD operations verified end-to-end in Docker
- Backend returns proper responses for create (201), update (200), delete (200)
- Frontend forms submit correctly and list refreshes

Closes #911