### PR TITLE
fix: add event_date type assertion for legacy field support #190

### DIFF
--- a/backend/src/controllers/event-controller.ts
+++ b/backend/src/controllers/event-controller.ts
@@ -392,7 +392,7 @@ export async function createEvent(req: Request, res: Response): Promise<void> {
       longitude,
       waitlist_enabled,
       event_time,
-    } = req.body as EventData & { start_date?: string; venue_name?: string };
+    } = req.body as EventData & { start_date?: string; venue_name?: string; event_date?: string };
 
     const date = _date || event_date || start_date;
     const location = _location || venue_name;
@@ -546,7 +546,7 @@ export async function updateEvent(req: Request, res: Response): Promise<void> {
       gallery_public,
       storage_quota_bytes,
       event_time,
-    } = req.body as EventData & { start_date?: string; venue_name?: string };
+    } = req.body as EventData & { start_date?: string; venue_name?: string; event_date?: string };
 
     const date = _date || event_date || start_date;
     const location = _location || venue_name;


### PR DESCRIPTION
## Fix TypeScript Compilation Errors on develop

This PR fixes TypeScript compilation errors by adding the `event_date?: string` type assertion that was previously only applied during promotion merges.

### Issue
- develop branch was missing TypeScript fixes that were applied to test/stage/main
- CI checks failing with: `Property 'event_date' does not exist on type 'EventData & { start_date?: string; venue_name?: string; }'`
- Branches were out of sync

### Changes
- Added `event_date?: string` to EventData type assertions in `createEvent` (line 395)
- Added `event_date?: string` to EventData type assertions in `updateEvent` (line 549)

### Testing
- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ Prettier format check passes
- ✅ Matches code in test/stage/main branches

### Related
- Part of #190 branch synchronization effort
- Fixes applied in PRs #916, #918, #919 now backported to develop

Closes #190