### PR TITLE
fix(quality): resolve Prettier formatting and TypeScript build errors #941

### DIFF
--- a/backend/src/controllers/events-controller.ts
+++ b/backend/src/controllers/events-controller.ts
@@ -202,9 +202,7 @@ export async function getEventStats(_req: Request, res: Response): Promise<Respo
         "SELECT COUNT(*) AS count FROM events WHERE status = 'Active' AND deleted_at IS NULL",
       ),
       db.get<{ count: number }>('SELECT COUNT(*) AS count FROM tasks'),
-      db.get<{ count: number }>(
-        "SELECT COUNT(*) AS count FROM tasks WHERE status = 'Pending'",
-      ),
+      db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE status = 'Pending'"),
       db.get<{ count: number }>('SELECT COUNT(*) AS count FROM rsvps'),
       db.get<{ count: number }>(
         "SELECT COUNT(*) AS count FROM rsvps WHERE canonical_status = 'confirmed'",

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -143,9 +143,7 @@ export async function authenticateToken(
 
   // Throttle last_activity updates to reduce write amplification.
   // Only update if more than 60 seconds have elapsed since last recorded activity.
-  const lastActivityMs = session.last_activity
-    ? new Date(session.last_activity).getTime()
-    : 0;
+  const lastActivityMs = session.last_activity ? new Date(session.last_activity).getTime() : 0;
   if (Date.now() - lastActivityMs > 60_000) {
     await db.run('UPDATE sessions SET last_activity = $1 WHERE id = $2', [
       new Date().toISOString(),

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -6,8 +6,7 @@ function createStore(prefix: string): RedisStore | undefined {
   const client = getRedisClient();
   if (!client) return undefined; // Falls back to express-rate-limit's built-in MemoryStore
   return new RedisStore({
-    sendCommand: (...args: string[]) =>
-      client.call(args[0], ...args.slice(1)) as never,
+    sendCommand: (...args: string[]) => client.call(args[0], ...args.slice(1)) as never,
     prefix: `rl:${prefix}:`,
   });
 }

--- a/backend/src/routes/guest.routes.ts
+++ b/backend/src/routes/guest.routes.ts
@@ -172,8 +172,16 @@ router.get(
 );
 
 // ============ GUEST GROUPS & BULK OPS — #667 ============
-router.get('/events/:eventId/guest-groups', authenticateToken, guestGroupsController.listGuestGroups);
-router.post('/events/:eventId/guest-groups', authenticateToken, guestGroupsController.createGuestGroup);
+router.get(
+  '/events/:eventId/guest-groups',
+  authenticateToken,
+  guestGroupsController.listGuestGroups,
+);
+router.post(
+  '/events/:eventId/guest-groups',
+  authenticateToken,
+  guestGroupsController.createGuestGroup,
+);
 router.put(
   '/events/:eventId/guest-groups/:id',
   authenticateToken,
@@ -216,7 +224,11 @@ router.delete(
 );
 
 // ============ MEAL OPTIONS (#591) ============
-router.get('/events/:eventId/meal-options', authenticateToken, mealOptionsController.listMealOptions);
+router.get(
+  '/events/:eventId/meal-options',
+  authenticateToken,
+  mealOptionsController.listMealOptions,
+);
 router.post(
   '/events/:eventId/meal-options',
   authenticateToken,

--- a/frontend/src/components/events/EventCreateEditDialog.tsx
+++ b/frontend/src/components/events/EventCreateEditDialog.tsx
@@ -61,7 +61,7 @@ export function EventCreateEditDialog({
   initialForm,
   onClose,
   onSaved,
-  onError,
+  onError: _onError,
 }: EventCreateEditDialogProps): JSX.Element {
   const [form, setForm] = useState<EventForm>({ ...EMPTY_FORM, ...initialForm });
   const [saving, setSaving] = useState(false);

--- a/frontend/src/components/events/EventDocumentsTab.tsx
+++ b/frontend/src/components/events/EventDocumentsTab.tsx
@@ -145,11 +145,23 @@ export function EventDocumentsTab({
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell><strong>Name</strong></TableCell>
-                <TableCell><strong>Type</strong></TableCell>
-                <TableCell><strong>Size</strong></TableCell>
-                <TableCell><strong>Uploaded</strong></TableCell>
-                {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
+                <TableCell>
+                  <strong>Name</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Type</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Size</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Uploaded</strong>
+                </TableCell>
+                {canEdit && (
+                  <TableCell align="right">
+                    <strong>Actions</strong>
+                  </TableCell>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>

--- a/frontend/src/components/events/EventListTable.tsx
+++ b/frontend/src/components/events/EventListTable.tsx
@@ -41,13 +41,13 @@ interface PlannerEvent {
   creator_name: string | null;
   event_type: string | null;
   tags: string | null;
-  latitude: number | null;
-  longitude: number | null;
-  waitlist_enabled: boolean | null;
-  event_time: string | null;
-  going_count: number | null;
-  pending_count: number | null;
-  created_by: number | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  waitlist_enabled?: boolean | null;
+  event_time?: string | null;
+  going_count?: number | null;
+  pending_count?: number | null;
+  created_by: number;
 }
 
 function capacityLabel(event: PlannerEvent): string {
@@ -159,12 +159,7 @@ export function EventListTable({
                 <TableCell>
                   {event.title}
                   {event.event_type && (
-                    <Chip
-                      label={event.event_type}
-                      size="small"
-                      variant="outlined"
-                      sx={{ ml: 1 }}
-                    />
+                    <Chip label={event.event_type} size="small" variant="outlined" sx={{ ml: 1 }} />
                   )}
                   {event.waitlist_enabled && (
                     <Tooltip title="Waitlist enabled for this event">
@@ -193,12 +188,7 @@ export function EventListTable({
                   <Stack direction="row" spacing={0.5} alignItems="center">
                     <Typography variant="body2">{capacityLabel(event)}</Typography>
                     {overflow && (
-                      <Chip
-                        label="Over capacity"
-                        size="small"
-                        color="error"
-                        variant="outlined"
-                      />
+                      <Chip label="Over capacity" size="small" color="error" variant="outlined" />
                     )}
                   </Stack>
                 </TableCell>

--- a/frontend/src/components/events/EventRsvpsTab.tsx
+++ b/frontend/src/components/events/EventRsvpsTab.tsx
@@ -179,12 +179,26 @@ export function EventRsvpsTab({
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell><strong>Name</strong></TableCell>
-                <TableCell><strong>Email</strong></TableCell>
-                <TableCell><strong>Guests</strong></TableCell>
-                <TableCell><strong>Status</strong></TableCell>
-                <TableCell><strong>Source</strong></TableCell>
-                {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
+                <TableCell>
+                  <strong>Name</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Email</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Guests</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Status</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Source</strong>
+                </TableCell>
+                {canEdit && (
+                  <TableCell align="right">
+                    <strong>Actions</strong>
+                  </TableCell>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -212,10 +226,19 @@ export function EventRsvpsTab({
                   {canEdit && (
                     <TableCell align="right">
                       <Stack direction="row" spacing={0.5} justifyContent="flex-end">
-                        <Button size="small" startIcon={<EditRounded />} onClick={() => openEditRsvp(r)}>
+                        <Button
+                          size="small"
+                          startIcon={<EditRounded />}
+                          onClick={() => openEditRsvp(r)}
+                        >
                           Edit
                         </Button>
-                        <Button size="small" color="error" startIcon={<DeleteRounded />} onClick={() => deleteRsvp(r.id)}>
+                        <Button
+                          size="small"
+                          color="error"
+                          startIcon={<DeleteRounded />}
+                          onClick={() => deleteRsvp(r.id)}
+                        >
                           Delete
                         </Button>
                       </Stack>

--- a/frontend/src/components/events/EventTasksTab.tsx
+++ b/frontend/src/components/events/EventTasksTab.tsx
@@ -160,12 +160,26 @@ export function EventTasksTab({
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell><strong>Title</strong></TableCell>
-                <TableCell><strong>Assignee</strong></TableCell>
-                <TableCell><strong>Due Date</strong></TableCell>
-                <TableCell><strong>Priority</strong></TableCell>
-                <TableCell><strong>Status</strong></TableCell>
-                {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
+                <TableCell>
+                  <strong>Title</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Assignee</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Due Date</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Priority</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Status</strong>
+                </TableCell>
+                {canEdit && (
+                  <TableCell align="right">
+                    <strong>Actions</strong>
+                  </TableCell>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -197,10 +211,19 @@ export function EventTasksTab({
                   {canEdit && (
                     <TableCell align="right">
                       <Stack direction="row" spacing={0.5} justifyContent="flex-end">
-                        <Button size="small" startIcon={<EditRounded />} onClick={() => openEditTask(t)}>
+                        <Button
+                          size="small"
+                          startIcon={<EditRounded />}
+                          onClick={() => openEditTask(t)}
+                        >
                           Edit
                         </Button>
-                        <Button size="small" color="error" startIcon={<DeleteRounded />} onClick={() => deleteTask(t.id)}>
+                        <Button
+                          size="small"
+                          color="error"
+                          startIcon={<DeleteRounded />}
+                          onClick={() => deleteTask(t.id)}
+                        >
                           Delete
                         </Button>
                       </Stack>

--- a/frontend/src/components/events/EventTeamTab.tsx
+++ b/frontend/src/components/events/EventTeamTab.tsx
@@ -77,7 +77,9 @@ export function EventTeamTab({
 
   async function removeMember(userId: number): Promise<void> {
     if (!window.confirm('Remove this team member?')) return;
-    await api.delete(`/api/events/${eventId}/members/${userId}`).catch((err) => onError(err.message));
+    await api
+      .delete(`/api/events/${eventId}/members/${userId}`)
+      .catch((err) => onError(err.message));
     await onRefresh();
   }
 
@@ -127,11 +129,23 @@ export function EventTeamTab({
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell><strong>Name</strong></TableCell>
-                <TableCell><strong>Email</strong></TableCell>
-                <TableCell><strong>Role</strong></TableCell>
-                <TableCell><strong>Joined</strong></TableCell>
-                {canEdit && <TableCell align="right"><strong>Actions</strong></TableCell>}
+                <TableCell>
+                  <strong>Name</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Email</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Role</strong>
+                </TableCell>
+                <TableCell>
+                  <strong>Joined</strong>
+                </TableCell>
+                {canEdit && (
+                  <TableCell align="right">
+                    <strong>Actions</strong>
+                  </TableCell>
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -143,7 +157,11 @@ export function EventTeamTab({
                   <TableCell>{new Date(member.joined_at).toLocaleString()}</TableCell>
                   {canEdit && (
                     <TableCell align="right">
-                      <Button size="small" color="error" onClick={() => removeMember(member.user_id)}>
+                      <Button
+                        size="small"
+                        color="error"
+                        onClick={() => removeMember(member.user_id)}
+                      >
                         Remove
                       </Button>
                     </TableCell>

--- a/frontend/src/components/events/events-page.tsx
+++ b/frontend/src/components/events/events-page.tsx
@@ -18,7 +18,6 @@ import {
   Paper,
   Stack,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import {

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -33,7 +33,8 @@ export function useEvents(filters?: Record<string, unknown>) {
     queryKey: EVENT_QUERY_KEYS.list(filters),
     queryFn: async () => {
       const params = filters
-        ? '?' + new URLSearchParams(
+        ? '?' +
+          new URLSearchParams(
             Object.entries(filters).reduce<Record<string, string>>((acc, [k, v]) => {
               if (v != null && v !== '') acc[k] = String(v);
               return acc;


### PR DESCRIPTION
## Summary

Follow-up fix for PR #942 (merged before CI completed). Resolves formatting and type errors caught by the CI pipeline.

## Changes
- **Prettier**: Format 10 files flagged by CI `format:check`
- **TypeScript**: Remove unused `Tooltip` import from `events-page.tsx`
- **TypeScript**: Prefix unused `onError` parameter in `EventCreateEditDialog`
- **TypeScript**: Align `EventListTable` `PlannerEvent` interface with service types (optional fields + non-null `created_by`)

## Validation
- `npm run build` passes in frontend
- `npx prettier --check` passes all files
- `tsc --noEmit` passes both frontend and backend

Closes #941