### PR TITLE
fix(ai): use api client for budget-insight to include CSRF and auth headers #952

### DIFF
--- a/frontend/src/services/budget-insight-service.ts
+++ b/frontend/src/services/budget-insight-service.ts
@@ -6,6 +6,8 @@
  * risk indicators, anomalies, and at least 3 actionable recommendations.
  */
 
+import { api } from '../lib/api-client';
+
 export interface BudgetRecommendation {
   category: string;
   insight: string;
@@ -41,17 +43,5 @@ export interface BudgetInsightRequest {
 export async function fetchBudgetInsight(
   request: BudgetInsightRequest,
 ): Promise<BudgetInsightResponse> {
-  const response = await fetch('/api/ai/budget-insight', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(request),
-  });
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { error?: string };
-    throw new Error(data.error ?? `Budget insight request failed (${response.status})`);
-  }
-
-  return response.json() as Promise<BudgetInsightResponse>;
+  return api.post<BudgetInsightResponse>('/api/ai/budget-insight', request);
 }


### PR DESCRIPTION
## Summary

The `fetchBudgetInsight` function in `budget-insight-service.ts` was using the raw `fetch` API instead of the shared `api` client. This caused the **Analyse Budget** feature to always fail with a generic "AI request failed." error.

## Changes

- **Budget insight service now uses the shared API client** (`api.post`) instead of raw `fetch`
- **CSRF headers are now included correctly** — the `api` client automatically attaches the `X-XSRF-Token` header (with auto-retry on token expiry)
- **Auth headers are now included correctly** — the JWT `Authorization` header is attached automatically
- **Improves authenticated AI request handling** — errors thrown are now `ApiError` instances, so the frontend correctly surfaces the actual backend error message instead of the fallback "AI request failed."

## Root Cause

`budget-insight-service.ts` called `fetch('/api/ai/budget-insight', ...)` directly, bypassing the shared `api-client` that handles CSRF tokens and Bearer auth. The backend's CSRF middleware rejected the unauthenticated request, and the plain `Error` thrown (not an `ApiError`) caused `resolveAiErrorMessage` to fall back to the generic message.

## Testing

- Backend health confirmed running on port 4000
- TypeScript compilation passes with no errors
- Docker containers rebuilt and restarted successfully

Closes #952