### PR TITLE
fix(backend): revert module to ES2020 and moduleResolution to node post-merge (#996)

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "Node16",
+    "module": "ES2020",
     "lib": ["ES2020"],
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "rootDir": "./src",
     "outDir": "./dist",
     "strict": true,

--- a/frontend/test/ai-assistant.test.tsx
+++ b/frontend/test/ai-assistant.test.tsx
@@ -772,9 +772,7 @@ describe('AiAssistant — #960 Task Breakdown happy path', () => {
     await userEvent.click(screen.getByRole('button', { name: /AI assistant/i }));
     await userEvent.click(screen.getByRole('tab', { name: /Task Plan/i }));
 
-    expect(
-      screen.getByRole('button', { name: /Generate task breakdown/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Generate task breakdown/i })).toBeDisabled();
   });
 });
 
@@ -803,7 +801,11 @@ describe('AiAssistant — #960 Budget Insight happy path', () => {
         },
       ],
       raw: '{}',
-      contextSummary: { groundedFields: ['budget', 'expenses'], categoryCount: 4, expenseCount: 20 },
+      contextSummary: {
+        groundedFields: ['budget', 'expenses'],
+        categoryCount: 4,
+        expenseCount: 20,
+      },
     });
 
     render(<AiAssistant />);
@@ -856,9 +858,7 @@ describe('AiAssistant — #960 Budget Insight happy path', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /Analyse budget/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/Budget is mostly on track/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Budget is mostly on track/i)).toBeInTheDocument());
   });
 
   it('renders recommendation category and action text', async () => {
@@ -945,9 +945,7 @@ describe('AiAssistant — #960 Budget Insight happy path', () => {
     await userEvent.click(screen.getByRole('button', { name: /AI assistant/i }));
     await userEvent.click(screen.getByRole('tab', { name: /Budget/i }));
 
-    expect(
-      screen.getByText(/Select an event and click Analyse Budget/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Select an event and click Analyse Budget/i)).toBeInTheDocument();
   });
 
   it('disables Analyse Budget button when no event is selected', async () => {

--- a/frontend/test/ai-contract.test.ts
+++ b/frontend/test/ai-contract.test.ts
@@ -93,7 +93,11 @@ describe('Budget Insight Service — request contract', () => {
         },
       ],
       raw: '{}',
-      contextSummary: { groundedFields: ['budget', 'expenses'], categoryCount: 3, expenseCount: 12 },
+      contextSummary: {
+        groundedFields: ['budget', 'expenses'],
+        categoryCount: 3,
+        expenseCount: 12,
+      },
     };
 
     mockedApi.post.mockResolvedValueOnce(expectedResponse);

--- a/frontend/test/vendor-ai-recommendation-panel.test.tsx
+++ b/frontend/test/vendor-ai-recommendation-panel.test.tsx
@@ -88,23 +88,17 @@ describe('VendorAiRecommendationPanel — initial render', () => {
 
   it('renders the Get Recommendations button in enabled state', () => {
     render(<VendorAiRecommendationPanel eventId={10} />);
-    expect(
-      screen.getByRole('button', { name: /Get Recommendations/i }),
-    ).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /Get Recommendations/i })).not.toBeDisabled();
   });
 
   it('accepts a numeric eventId', () => {
     render(<VendorAiRecommendationPanel eventId={10} />);
-    expect(
-      screen.getByRole('button', { name: /Get Recommendations/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Get Recommendations/i })).toBeInTheDocument();
   });
 
   it('accepts a string eventId without crashing', () => {
     render(<VendorAiRecommendationPanel eventId="10" />);
-    expect(
-      screen.getByRole('button', { name: /Get Recommendations/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Get Recommendations/i })).toBeInTheDocument();
   });
 });
 
@@ -135,9 +129,7 @@ describe('VendorAiRecommendationPanel — loading state', () => {
     render(<VendorAiRecommendationPanel eventId={10} />);
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
-    expect(
-      screen.getByRole('textbox', { name: /Optional recommendation prompt/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /Optional recommendation prompt/i })).toBeDisabled();
   });
 });
 
@@ -151,9 +143,7 @@ describe('VendorAiRecommendationPanel — error state', () => {
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
     // The advisory info alert is always present; wait for the error text specifically.
-    await waitFor(() =>
-      expect(screen.getByText(/Service unavailable/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Service unavailable/i)).toBeInTheDocument());
   });
 
   it('re-enables the button after an error', async () => {
@@ -163,9 +153,7 @@ describe('VendorAiRecommendationPanel — error state', () => {
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Get Recommendations/i }),
-      ).not.toBeDisabled(),
+      expect(screen.getByRole('button', { name: /Get Recommendations/i })).not.toBeDisabled(),
     );
   });
 
@@ -258,9 +246,7 @@ describe('VendorAiRecommendationPanel — happy path', () => {
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
     await waitFor(() =>
-      expect(
-        screen.getByText(/Excellent track record for outdoor events/i),
-      ).toBeInTheDocument(),
+      expect(screen.getByText(/Excellent track record for outdoor events/i)).toBeInTheDocument(),
     );
   });
 
@@ -309,9 +295,7 @@ describe('VendorAiRecommendationPanel — happy path', () => {
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /Get Recommendations/i }),
-      ).not.toBeDisabled(),
+      expect(screen.getByRole('button', { name: /Get Recommendations/i })).not.toBeDisabled(),
     );
   });
 });
@@ -330,9 +314,7 @@ describe('VendorAiRecommendationPanel — empty recommendations', () => {
     await userEvent.click(screen.getByRole('button', { name: /Get Recommendations/i }));
 
     await waitFor(() =>
-      expect(
-        screen.getByText(/No ranked recommendations could be generated/i),
-      ).toBeInTheDocument(),
+      expect(screen.getByText(/No ranked recommendations could be generated/i)).toBeInTheDocument(),
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up fix for #997. The auto-merge on #997 captured the original (uncorrected) commit before force-push amendments could take effect. This PR applies the intended correct state to `develop`.

---

## Problem

PR #997 was auto-merged at 11:32 UTC with commit `babb3d2`, which set:
- `module: Node16`
- `moduleResolution: node16`

These settings require explicit `.js` file extensions on **all** relative imports. The backend has ~70 TypeScript errors without them.

## Fix

Reverts `module` and `moduleResolution` to the pre-existing stable values while preserving the valid `rootDir: ./src` addition.

---

## Changes

**File changed:** `backend/tsconfig.json`

| Setting | Was (after #997) | Now (this PR) |
|---|---|---|
| `module` | `Node16` | `ES2020` |
| `moduleResolution` | `node16` | `node` |
| `rootDir` | `./src` | `./src` (preserved) |

Also applies Prettier formatting to three frontend test files with pre-existing style violations.

---

## Testing

- [x] `tsc --noEmit` passes (no TS errors)
- [x] Prettier passes
- [x] All CI jobs expected to pass (Lint, Tests, Build, Security, CodeQL)

> **Allowed infra failures:** `E2E Tests (Playwright)`, `Lighthouse CI Gate`, `Load Test / k6 Smoke`

---

## Related

Fixes #996