### PR TITLE
feat(ai): add human-in-the-loop apply flow for AI suggestions #965

### DIFF
--- a/backend/src/controllers/ai-controller.ts
+++ b/backend/src/controllers/ai-controller.ts
@@ -2754,6 +2754,152 @@ export async function getAnalyticsNarrative(req: AuthRequest, res: Response): Pr
 
 // ── AI Observability Health Endpoint — Issue #958 ─────────────────────────────
 
+// ── Human-in-the-Loop Apply Flow (#965) ──────────────────────────────────────
+
+interface AiApplyBody {
+  /** Originating workflow type (e.g. 'event', 'task', 'rsvp', 'general'). */
+  workflowType: string;
+  /** Entity the suggestion pertains to (event / task ID). May be null for general context. */
+  entityId: number | null;
+  /**
+   * The full suggestion content as surfaced to the user.
+   * May be the edited version when the user chose to modify before applying.
+   */
+  suggestionContent: string;
+  /** Optional actor-supplied note (e.g. "applied with minor edits"). */
+  note?: string;
+}
+
+interface AiAppliedRecord {
+  id: number;
+  userId: number;
+  workflowType: string;
+  entityId: number | null;
+  suggestionContent: string;
+  note: string | null;
+  appliedAt: string;
+}
+
+/**
+ * POST /api/ai/apply
+ *
+ * Records that an authenticated user explicitly applied (accepted) an AI
+ * suggestion.  The applied record is persisted to `ai_applied_suggestions`
+ * with the actor's user_id and a server-side timestamp so the audit trail is
+ * tamper-resistant.  Returns the created record for client-side display.
+ *
+ * Story #965 — Add Human-in-the-Loop Apply Flow for AI Suggestions.
+ */
+export async function applyAiSuggestion(req: AuthRequest, res: Response): Promise<Response> {
+  const { workflowType, entityId, suggestionContent, note } =
+    req.body as Partial<AiApplyBody>;
+
+  if (!workflowType?.trim()) {
+    return res.status(400).json({ error: 'workflowType is required.' });
+  }
+  if (!suggestionContent?.trim()) {
+    return res.status(400).json({ error: 'suggestionContent is required.' });
+  }
+
+  const userId = req.user?.id;
+  if (userId === undefined) {
+    return res.status(401).json({ error: 'Unauthorized.' });
+  }
+
+  try {
+    const db = getDatabase();
+
+    // Ensure the audit table exists (best-effort DDL on first use).
+    await db.run(
+      `CREATE TABLE IF NOT EXISTS ai_applied_suggestions (
+         id            SERIAL PRIMARY KEY,
+         user_id       INTEGER NOT NULL,
+         workflow_type TEXT    NOT NULL,
+         entity_id     INTEGER,
+         suggestion_content TEXT NOT NULL,
+         note          TEXT,
+         applied_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+       )`,
+    ).catch(() => {
+      // Table may already exist; ignore.
+    });
+
+    const row = await db.get<AiAppliedRecord>(
+      `INSERT INTO ai_applied_suggestions
+         (user_id, workflow_type, entity_id, suggestion_content, note, applied_at)
+       VALUES ($1, $2, $3, $4, $5, NOW())
+       RETURNING id, user_id AS "userId", workflow_type AS "workflowType",
+                 entity_id AS "entityId", suggestion_content AS "suggestionContent",
+                 note, applied_at AS "appliedAt"`,
+      [
+        userId,
+        workflowType.trim(),
+        typeof entityId === 'number' ? entityId : null,
+        suggestionContent.trim(),
+        note?.trim() ?? null,
+      ],
+    );
+
+    void logAiAuditEvent({
+      userId,
+      workflowType: workflowType.trim(),
+      entityId: typeof entityId === 'number' ? entityId : null,
+      provider: 'app',
+      durationMs: 0,
+      outcome: 'success',
+    });
+
+    return res.status(201).json(row);
+  } catch (err) {
+    const message = buildSafeErrorMessage(err);
+    return res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * DELETE /api/ai/apply/:id
+ *
+ * Rolls back an applied AI suggestion by deleting the audit record identified
+ * by `:id`.  Only the user who applied the suggestion may roll it back (row-
+ * level ownership check).  Returns 204 on success, 404 if not found or not
+ * owned by the requesting user.
+ *
+ * Story #965 — Add Human-in-the-Loop Apply Flow for AI Suggestions.
+ */
+export async function rollbackAiSuggestion(req: AuthRequest, res: Response): Promise<Response> {
+  const applyId = parseInt(req.params.id ?? '', 10);
+  if (isNaN(applyId) || applyId <= 0) {
+    return res.status(400).json({ error: 'Invalid apply ID.' });
+  }
+
+  const userId = req.user?.id;
+  if (userId === undefined) {
+    return res.status(401).json({ error: 'Unauthorized.' });
+  }
+
+  try {
+    const db = getDatabase();
+    const result = await db.run(
+      `DELETE FROM ai_applied_suggestions WHERE id = $1 AND user_id = $2`,
+      [applyId, userId],
+    );
+
+    // `result.changes` (SQLite) or rowCount (pg) — treat 0 as not-found.
+    const affected = (result as { changes?: number; rowCount?: number }).changes
+      ?? (result as { rowCount?: number }).rowCount
+      ?? 0;
+
+    if (affected === 0) {
+      return res.status(404).json({ error: 'Applied suggestion not found or access denied.' });
+    }
+
+    return res.status(204).send();
+  } catch (err) {
+    const message = buildSafeErrorMessage(err);
+    return res.status(500).json({ error: message });
+  }
+}
+
 /**
  * GET /api/ai/health
  *

--- a/backend/src/controllers/ai-controller.ts
+++ b/backend/src/controllers/ai-controller.ts
@@ -2791,8 +2791,7 @@ interface AiAppliedRecord {
  * Story #965 — Add Human-in-the-Loop Apply Flow for AI Suggestions.
  */
 export async function applyAiSuggestion(req: AuthRequest, res: Response): Promise<Response> {
-  const { workflowType, entityId, suggestionContent, note } =
-    req.body as Partial<AiApplyBody>;
+  const { workflowType, entityId, suggestionContent, note } = req.body as Partial<AiApplyBody>;
 
   if (!workflowType?.trim()) {
     return res.status(400).json({ error: 'workflowType is required.' });
@@ -2810,8 +2809,9 @@ export async function applyAiSuggestion(req: AuthRequest, res: Response): Promis
     const db = getDatabase();
 
     // Ensure the audit table exists (best-effort DDL on first use).
-    await db.run(
-      `CREATE TABLE IF NOT EXISTS ai_applied_suggestions (
+    await db
+      .run(
+        `CREATE TABLE IF NOT EXISTS ai_applied_suggestions (
          id            SERIAL PRIMARY KEY,
          user_id       INTEGER NOT NULL,
          workflow_type TEXT    NOT NULL,
@@ -2820,9 +2820,10 @@ export async function applyAiSuggestion(req: AuthRequest, res: Response): Promis
          note          TEXT,
          applied_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
        )`,
-    ).catch(() => {
-      // Table may already exist; ignore.
-    });
+      )
+      .catch(() => {
+        // Table may already exist; ignore.
+      });
 
     const row = await db.get<AiAppliedRecord>(
       `INSERT INTO ai_applied_suggestions
@@ -2851,7 +2852,7 @@ export async function applyAiSuggestion(req: AuthRequest, res: Response): Promis
 
     return res.status(201).json(row);
   } catch (err) {
-    const message = buildSafeErrorMessage(err);
+    const message = buildSafeErrorMessage(err, 'app');
     return res.status(500).json({ error: message });
   }
 }
@@ -2885,9 +2886,10 @@ export async function rollbackAiSuggestion(req: AuthRequest, res: Response): Pro
     );
 
     // `result.changes` (SQLite) or rowCount (pg) — treat 0 as not-found.
-    const affected = (result as { changes?: number; rowCount?: number }).changes
-      ?? (result as { rowCount?: number }).rowCount
-      ?? 0;
+    const affected =
+      (result as { changes?: number; rowCount?: number }).changes ??
+      (result as { rowCount?: number }).rowCount ??
+      0;
 
     if (affected === 0) {
       return res.status(404).json({ error: 'Applied suggestion not found or access denied.' });
@@ -2895,7 +2897,7 @@ export async function rollbackAiSuggestion(req: AuthRequest, res: Response): Pro
 
     return res.status(204).send();
   } catch (err) {
-    const message = buildSafeErrorMessage(err);
+    const message = buildSafeErrorMessage(err, 'app');
     return res.status(500).json({ error: message });
   }
 }

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -225,6 +225,22 @@ router.post(
 // needing AI feature entitlements.
 router.get('/ai/health', authenticateToken, aiController.getAiHealth);
 
+// Story #965 — Human-in-the-Loop Apply Flow.
+// POST records an applied suggestion (actor + timestamp audit trail).
+// DELETE rolls back a previously applied suggestion (ownership-checked).
+router.post(
+  '/ai/apply',
+  authenticateToken,
+  requireAiAccess,
+  aiController.applyAiSuggestion,
+);
+router.delete(
+  '/ai/apply/:id',
+  authenticateToken,
+  requireAiAccess,
+  aiController.rollbackAiSuggestion,
+);
+
 // ============ PUBLIC RSVP ROUTES ==========
 // All unauthenticated public endpoints share a tighter per-IP limiter
 // (publicLimiter) on top of the global apiLimiter so a single attacker IP

--- a/backend/src/routes/api-routes.ts
+++ b/backend/src/routes/api-routes.ts
@@ -228,12 +228,7 @@ router.get('/ai/health', authenticateToken, aiController.getAiHealth);
 // Story #965 — Human-in-the-Loop Apply Flow.
 // POST records an applied suggestion (actor + timestamp audit trail).
 // DELETE rolls back a previously applied suggestion (ownership-checked).
-router.post(
-  '/ai/apply',
-  authenticateToken,
-  requireAiAccess,
-  aiController.applyAiSuggestion,
-);
+router.post('/ai/apply', authenticateToken, requireAiAccess, aiController.applyAiSuggestion);
 router.delete(
   '/ai/apply/:id',
   authenticateToken,

--- a/frontend/src/components/ai/ai-suggestion-review.tsx
+++ b/frontend/src/components/ai/ai-suggestion-review.tsx
@@ -1,0 +1,317 @@
+/**
+ * AI Suggestion Review Panel — Human-in-the-Loop Apply Flow (#965).
+ *
+ * Renders an AI suggestion in a review card that exposes three actions:
+ *   - Accept   — applies the suggestion as-is via POST /api/ai/apply
+ *   - Edit & Apply — lets the user modify the suggestion text then applies
+ *   - Reject   — dismisses the suggestion (no server call)
+ *
+ * Applied suggestions are persisted with actor ID and server-side timestamp
+ * for audit traceability.  Rollback is available for each applied record via
+ * DELETE /api/ai/apply/:id.
+ *
+ * Usage:
+ * ```tsx
+ * <AiSuggestionReview
+ *   workflowType="event"
+ *   entityId={selectedEvent.id}
+ *   suggestionContent={workflowResult.raw}
+ *   onReject={() => setWorkflowResult(null)}
+ * />
+ * ```
+ */
+
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  CheckCircleOutlineRounded,
+  DeleteOutlineRounded,
+  EditOutlined,
+  UndoRounded,
+} from '@mui/icons-material';
+import { api, ApiError } from '../../lib/api-client';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AiAppliedRecord {
+  id: number;
+  userId: number;
+  workflowType: string;
+  entityId: number | null;
+  suggestionContent: string;
+  note: string | null;
+  appliedAt: string;
+}
+
+export interface AiSuggestionReviewProps {
+  /** Originating workflow context (e.g. 'event', 'task', 'rsvp', 'general'). */
+  workflowType: string;
+  /** Entity the suggestion refers to. Null for general / chat context. */
+  entityId: number | null;
+  /** The full suggestion text to review. */
+  suggestionContent: string;
+  /** Optional user-visible label for the suggestion type. */
+  label?: string;
+  /** Called when the user dismisses/rejects the suggestion. */
+  onReject: () => void;
+  /** Called after a successful apply with the returned audit record. */
+  onApplied?: (record: AiAppliedRecord) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AiSuggestionReview({
+  workflowType,
+  entityId,
+  suggestionContent,
+  label,
+  onReject,
+  onApplied,
+}: AiSuggestionReviewProps): JSX.Element {
+  const [editMode, setEditMode] = useState(false);
+  const [editedContent, setEditedContent] = useState(suggestionContent);
+  const [applying, setApplying] = useState(false);
+  const [rollingBack, setRollingBack] = useState(false);
+  const [appliedRecord, setAppliedRecord] = useState<AiAppliedRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rollbackDone, setRollbackDone] = useState(false);
+
+  // ── Apply ────────────────────────────────────────────────────────────────
+
+  async function handleApply(content: string): Promise<void> {
+    setApplying(true);
+    setError(null);
+    try {
+      const record = await api.post<AiAppliedRecord>('/api/ai/apply', {
+        workflowType,
+        entityId,
+        suggestionContent: content,
+        note: editMode ? 'applied with user edits' : undefined,
+      });
+      setAppliedRecord(record);
+      setEditMode(false);
+      onApplied?.(record);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setError('You do not have permission to apply AI suggestions.');
+      } else {
+        setError(err instanceof ApiError ? err.message : 'Failed to apply suggestion.');
+      }
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  // ── Rollback ─────────────────────────────────────────────────────────────
+
+  async function handleRollback(): Promise<void> {
+    if (!appliedRecord) return;
+    setRollingBack(true);
+    setError(null);
+    try {
+      await api.delete(`/api/ai/apply/${appliedRecord.id}`);
+      setAppliedRecord(null);
+      setRollbackDone(true);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to roll back suggestion.');
+    } finally {
+      setRollingBack(false);
+    }
+  }
+
+  // ── Post-rollback state ───────────────────────────────────────────────────
+
+  if (rollbackDone) {
+    return (
+      <Alert severity="info" sx={{ mt: 1 }}>
+        Suggestion rolled back. No changes were applied.
+      </Alert>
+    );
+  }
+
+  // ── Applied confirmation ──────────────────────────────────────────────────
+
+  if (appliedRecord) {
+    return (
+      <Box
+        sx={{
+          border: 1,
+          borderColor: 'success.light',
+          borderRadius: 2,
+          p: 1.5,
+          bgcolor: 'success.50',
+        }}
+      >
+        <Stack direction="row" alignItems="center" justifyContent="space-between" mb={0.5}>
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            <CheckCircleOutlineRounded color="success" fontSize="small" />
+            <Typography variant="caption" color="success.main" fontWeight={700}>
+              Suggestion applied
+            </Typography>
+          </Stack>
+          <Chip
+            label={new Date(appliedRecord.appliedAt).toLocaleTimeString()}
+            size="small"
+            variant="outlined"
+            color="success"
+          />
+        </Stack>
+        {appliedRecord.note && (
+          <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>
+            {appliedRecord.note}
+          </Typography>
+        )}
+        <Typography variant="caption" color="text.disabled" display="block" mb={1}>
+          Audit ID: #{appliedRecord.id} · Applied by user #{appliedRecord.userId}
+        </Typography>
+        <Tooltip title="Undo: remove this applied suggestion record">
+          <span>
+            <Button
+              size="small"
+              startIcon={rollingBack ? <CircularProgress size={14} /> : <UndoRounded />}
+              onClick={handleRollback}
+              disabled={rollingBack}
+              color="warning"
+              variant="outlined"
+            >
+              {rollingBack ? 'Rolling back…' : 'Roll back'}
+            </Button>
+          </span>
+        </Tooltip>
+        {error && (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {error}
+          </Alert>
+        )}
+      </Box>
+    );
+  }
+
+  // ── Review panel ─────────────────────────────────────────────────────────
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: 'primary.light',
+        borderRadius: 2,
+        p: 1.5,
+        bgcolor: 'primary.50',
+      }}
+      aria-label="AI suggestion review panel"
+    >
+      <Typography variant="caption" color="primary" fontWeight={700} display="block" mb={0.5}>
+        {label ?? 'AI Suggestion — Review before applying'}
+      </Typography>
+
+      {/* Suggestion content (read-only or editable) */}
+      <Collapse in={!editMode}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ whiteSpace: 'pre-wrap', mb: 1 }}
+        >
+          {suggestionContent}
+        </Typography>
+      </Collapse>
+
+      <Collapse in={editMode}>
+        <TextField
+          multiline
+          minRows={3}
+          maxRows={10}
+          fullWidth
+          size="small"
+          value={editedContent}
+          onChange={(e) => setEditedContent(e.target.value)}
+          label="Edit suggestion before applying"
+          sx={{ mb: 1 }}
+          inputProps={{ 'aria-label': 'Edit AI suggestion content' }}
+        />
+      </Collapse>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Action row */}
+      <Stack direction="row" gap={1} flexWrap="wrap">
+        {/* Accept */}
+        <Tooltip title="Apply this suggestion as-is">
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              startIcon={applying ? <CircularProgress size={14} /> : <CheckCircleOutlineRounded />}
+              onClick={() => handleApply(editMode ? editedContent : suggestionContent)}
+              disabled={applying || (editMode && !editedContent.trim())}
+              aria-label="Accept and apply AI suggestion"
+            >
+              {applying ? 'Applying…' : 'Accept'}
+            </Button>
+          </span>
+        </Tooltip>
+
+        {/* Edit & Apply toggle */}
+        {!editMode ? (
+          <Tooltip title="Edit suggestion before applying">
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<EditOutlined />}
+              onClick={() => setEditMode(true)}
+              disabled={applying}
+              aria-label="Edit AI suggestion before applying"
+            >
+              Edit & Apply
+            </Button>
+          </Tooltip>
+        ) : (
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={() => {
+              setEditMode(false);
+              setEditedContent(suggestionContent);
+            }}
+            disabled={applying}
+          >
+            Cancel edit
+          </Button>
+        )}
+
+        {/* Reject */}
+        <Tooltip title="Dismiss this suggestion without applying">
+          <IconButton
+            size="small"
+            color="default"
+            onClick={onReject}
+            disabled={applying}
+            aria-label="Reject AI suggestion"
+          >
+            <DeleteOutlineRounded fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/components/ai/ai-suggestion-review.tsx
+++ b/frontend/src/components/ai/ai-suggestion-review.tsx
@@ -227,7 +227,7 @@ export function AiSuggestionReview({
         </Typography>
       </Collapse>
 
-      <Collapse in={editMode}>
+      <Collapse in={editMode} unmountOnExit>
         <TextField
           multiline
           minRows={3}

--- a/frontend/src/components/ai/ai-suggestion-review.tsx
+++ b/frontend/src/components/ai/ai-suggestion-review.tsx
@@ -28,7 +28,6 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Collapse,
   IconButton,
   Stack,
   TextField,
@@ -221,13 +220,7 @@ export function AiSuggestionReview({
       </Typography>
 
       {/* Suggestion content (read-only or editable) */}
-      <Collapse in={!editMode}>
-        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
-          {suggestionContent}
-        </Typography>
-      </Collapse>
-
-      <Collapse in={editMode} unmountOnExit>
+      {editMode ? (
         <TextField
           multiline
           minRows={3}
@@ -240,7 +233,11 @@ export function AiSuggestionReview({
           sx={{ mb: 1 }}
           inputProps={{ 'aria-label': 'Edit AI suggestion content' }}
         />
-      </Collapse>
+      ) : (
+        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
+          {suggestionContent}
+        </Typography>
+      )}
 
       {error && (
         <Alert severity="error" sx={{ mb: 1 }}>

--- a/frontend/src/components/ai/ai-suggestion-review.tsx
+++ b/frontend/src/components/ai/ai-suggestion-review.tsx
@@ -222,11 +222,7 @@ export function AiSuggestionReview({
 
       {/* Suggestion content (read-only or editable) */}
       <Collapse in={!editMode}>
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ whiteSpace: 'pre-wrap', mb: 1 }}
-        >
+        <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
           {suggestionContent}
         </Typography>
       </Collapse>

--- a/frontend/test/ai-suggestion-review.test.tsx
+++ b/frontend/test/ai-suggestion-review.test.tsx
@@ -87,9 +87,7 @@ describe('AiSuggestionReview — render', () => {
     expect(
       screen.getByRole('button', { name: /accept and apply ai suggestion/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /reject ai suggestion/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject ai suggestion/i })).toBeInTheDocument();
   });
 });
 
@@ -147,7 +145,10 @@ describe('AiSuggestionReview — Edit & Apply', () => {
   });
 
   it('applies the edited content with a note when user saves from edit mode', async () => {
-    mockedApi.post.mockResolvedValueOnce({ ...MOCK_APPLIED_RECORD, note: 'applied with user edits' });
+    mockedApi.post.mockResolvedValueOnce({
+      ...MOCK_APPLIED_RECORD,
+      note: 'applied with user edits',
+    });
     render(<AiSuggestionReview {...defaultProps} />);
 
     await userEvent.click(screen.getByRole('button', { name: /edit.*apply/i }));

--- a/frontend/test/ai-suggestion-review.test.tsx
+++ b/frontend/test/ai-suggestion-review.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tests: AiSuggestionReview component — Story #965
+ *
+ * Covers:
+ * - Renders suggestion content and three action controls
+ * - Accept: calls POST /api/ai/apply and shows applied confirmation
+ * - Edit & Apply: switches to edit mode and calls POST /api/ai/apply with edited content
+ * - Reject: calls onReject callback without a server round-trip
+ * - Rollback: calls DELETE /api/ai/apply/:id and shows rollback-done state
+ * - Error handling: displays alert when apply fails
+ * - Accessibility: ARIA labels on interactive elements
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AiSuggestionReview } from '../src/components/ai/ai-suggestion-review';
+import { api, ApiError } from '../src/lib/api-client';
+
+vi.mock('../src/lib/api-client', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/lib/api-client')>('../src/lib/api-client');
+  return {
+    ...actual,
+    api: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+const mockedApi = vi.mocked(api);
+
+const MOCK_SUGGESTION = 'Plan an outdoor festival with a main stage and food vendors.';
+const MOCK_APPLIED_RECORD = {
+  id: 42,
+  userId: 7,
+  workflowType: 'event',
+  entityId: 1,
+  suggestionContent: MOCK_SUGGESTION,
+  note: null,
+  appliedAt: '2026-05-28T10:00:00.000Z',
+};
+
+const defaultProps = {
+  workflowType: 'event',
+  entityId: 1,
+  suggestionContent: MOCK_SUGGESTION,
+  onReject: vi.fn(),
+};
+
+beforeEach(() => {
+  mockedApi.post.mockReset();
+  mockedApi.delete.mockReset();
+  vi.mocked(defaultProps.onReject).mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Render ─────────────────────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — render', () => {
+  it('renders the suggestion content', () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    expect(screen.getByText(MOCK_SUGGESTION)).toBeInTheDocument();
+  });
+
+  it('renders Accept, Edit & Apply, and Reject controls', () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /accept/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit.*apply/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it('uses the custom label when provided', () => {
+    render(<AiSuggestionReview {...defaultProps} label="Vendor Recommendation" />);
+    expect(screen.getByText(/vendor recommendation/i)).toBeInTheDocument();
+  });
+
+  it('has accessible ARIA labels on action buttons', () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /accept and apply ai suggestion/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /reject ai suggestion/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Accept (apply as-is) ───────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — Accept', () => {
+  it('calls POST /api/ai/apply with correct payload on Accept', async () => {
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    render(<AiSuggestionReview {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+
+    await waitFor(() => {
+      expect(mockedApi.post).toHaveBeenCalledWith('/api/ai/apply', {
+        workflowType: 'event',
+        entityId: 1,
+        suggestionContent: MOCK_SUGGESTION,
+        note: undefined,
+      });
+    });
+  });
+
+  it('shows applied confirmation with audit ID after successful apply', async () => {
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    render(<AiSuggestionReview {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/suggestion applied/i)).toBeInTheDocument();
+      expect(screen.getByText(/audit id.*#42/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onApplied callback with the returned record', async () => {
+    const onApplied = vi.fn();
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    render(<AiSuggestionReview {...defaultProps} onApplied={onApplied} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+
+    await waitFor(() => {
+      expect(onApplied).toHaveBeenCalledWith(MOCK_APPLIED_RECORD);
+    });
+  });
+});
+
+// ── Edit & Apply ───────────────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — Edit & Apply', () => {
+  it('switches to edit mode on Edit & Apply click', async () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /edit.*apply/i }));
+    expect(screen.getByLabelText(/edit ai suggestion content/i)).toBeInTheDocument();
+  });
+
+  it('applies the edited content with a note when user saves from edit mode', async () => {
+    mockedApi.post.mockResolvedValueOnce({ ...MOCK_APPLIED_RECORD, note: 'applied with user edits' });
+    render(<AiSuggestionReview {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /edit.*apply/i }));
+
+    const textarea = screen.getByLabelText(/edit ai suggestion content/i);
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, 'Edited suggestion text.');
+
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+
+    await waitFor(() => {
+      expect(mockedApi.post).toHaveBeenCalledWith('/api/ai/apply', {
+        workflowType: 'event',
+        entityId: 1,
+        suggestionContent: 'Edited suggestion text.',
+        note: 'applied with user edits',
+      });
+    });
+  });
+
+  it('restores original content on Cancel edit', async () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /edit.*apply/i }));
+    await userEvent.click(screen.getByRole('button', { name: /cancel edit/i }));
+    expect(screen.getByText(MOCK_SUGGESTION)).toBeInTheDocument();
+  });
+});
+
+// ── Reject ─────────────────────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — Reject', () => {
+  it('calls onReject without making an API call', async () => {
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /reject ai suggestion/i }));
+    expect(defaultProps.onReject).toHaveBeenCalledOnce();
+    expect(mockedApi.post).not.toHaveBeenCalled();
+  });
+});
+
+// ── Rollback ───────────────────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — Rollback', () => {
+  it('shows Roll back button after successful apply', async () => {
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /roll back/i })).toBeInTheDocument();
+    });
+  });
+
+  it('calls DELETE /api/ai/apply/:id on Roll back', async () => {
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    mockedApi.delete.mockResolvedValueOnce(undefined);
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+    await waitFor(() => screen.getByRole('button', { name: /roll back/i }));
+    await userEvent.click(screen.getByRole('button', { name: /roll back/i }));
+    await waitFor(() => {
+      expect(mockedApi.delete).toHaveBeenCalledWith('/api/ai/apply/42');
+    });
+  });
+
+  it('shows rollback-done state after successful rollback', async () => {
+    mockedApi.post.mockResolvedValueOnce(MOCK_APPLIED_RECORD);
+    mockedApi.delete.mockResolvedValueOnce(undefined);
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+    await waitFor(() => screen.getByRole('button', { name: /roll back/i }));
+    await userEvent.click(screen.getByRole('button', { name: /roll back/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/suggestion rolled back/i)).toBeInTheDocument();
+    });
+  });
+});
+
+// ── Error handling ─────────────────────────────────────────────────────────────
+
+describe('AiSuggestionReview — error handling', () => {
+  it('shows error alert when apply fails', async () => {
+    mockedApi.post.mockRejectedValueOnce(new ApiError('AI service unavailable.', 503));
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/ai service unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows permission error for 403 response', async () => {
+    mockedApi.post.mockRejectedValueOnce(new ApiError('Forbidden', 403));
+    render(<AiSuggestionReview {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /accept and apply/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/permission/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #965

## Summary
Implements a review-before-apply UI for AI suggestions with full audit trail and rollback capability.

## Changes
- `frontend/src/components/ai/ai-suggestion-review.tsx` (new) — Accept / Edit & Apply / Reject with rollback
- `frontend/test/ai-suggestion-review.test.tsx` (new) — unit tests
- `backend/src/controllers/ai-controller.ts` — POST /api/ai/apply + DELETE /api/ai/apply/:id
- `backend/src/routes/api-routes.ts` — route registrations with full auth middleware