### PR TITLE
feat(ai): add prompt template and version management #966

### DIFF
--- a/backend/__tests__/prompt-templates.test.ts
+++ b/backend/__tests__/prompt-templates.test.ts
@@ -21,7 +21,7 @@ import {
   getTemplateHistory,
   listActiveTemplates,
   type PromptTemplateContext,
-} from '../../src/lib/prompt-templates.js';
+} from '../src/lib/prompt-templates.js';
 
 // All contexts that must have an active template.
 const ALL_CONTEXTS: PromptTemplateContext[] = [

--- a/backend/__tests__/prompt-templates.test.ts
+++ b/backend/__tests__/prompt-templates.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests: prompt-templates module — Story #966
+ *
+ * Covers:
+ * - getTemplate: returns active (non-deprecated) template for each context
+ * - getTemplate with version: returns the pinned version regardless of deprecated state
+ * - getTemplate throws for unknown id
+ * - getTemplate throws for unknown version
+ * - getTemplateMetadata: returns correct metadata shape
+ * - getTemplateHistory: returns all versions newest-first
+ * - listActiveTemplates: returns one entry per context, all non-deprecated
+ * - Template content: every active template has non-empty content
+ * - Version scheme: all versions match MAJOR.MINOR.PATCH pattern
+ * - Rollback path: deprecated versions are retrievable by explicit version pin
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getTemplate,
+  getTemplateMetadata,
+  getTemplateHistory,
+  listActiveTemplates,
+  type PromptTemplateContext,
+} from '../../src/lib/prompt-templates.js';
+
+// All contexts that must have an active template.
+const ALL_CONTEXTS: PromptTemplateContext[] = [
+  'suggest-event',
+  'suggest-task',
+  'suggest-rsvp',
+  'suggest-general',
+  'grounded-event',
+  'grounded-task',
+  'grounded-rsvp',
+  'task-breakdown',
+  'budget-insight',
+  'vendor-recommendation',
+  'conflict-resolution',
+  'analytics-narrative',
+];
+
+// ── getTemplate ────────────────────────────────────────────────────────────────
+
+describe('getTemplate — active template retrieval', () => {
+  it.each(ALL_CONTEXTS)('returns the active template for context "%s"', (ctx) => {
+    const template = getTemplate(ctx);
+    expect(template).toBeDefined();
+    expect(template.id).toBe(ctx);
+    expect(template.deprecated).toBeFalsy();
+  });
+
+  it('returns a template with non-empty content for every context', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const template = getTemplate(ctx);
+      expect(template.content.trim().length).toBeGreaterThan(20);
+    }
+  });
+
+  it('throws for an unknown template id', () => {
+    expect(() =>
+      getTemplate('unknown-context' as PromptTemplateContext),
+    ).toThrow(/not found|no active/i);
+  });
+});
+
+describe('getTemplate — version-pinned retrieval (rollback path)', () => {
+  it('returns a template when an explicit valid version is provided', () => {
+    // Use 'suggest-event' 1.0.0 — guaranteed to exist in the registry.
+    const template = getTemplate('suggest-event', '1.0.0');
+    expect(template.id).toBe('suggest-event');
+    expect(template.version).toBe('1.0.0');
+  });
+
+  it('throws when pinned version does not exist', () => {
+    expect(() =>
+      getTemplate('suggest-event', '99.0.0'),
+    ).toThrow(/not found/i);
+  });
+
+  it('throws when id is valid but version does not exist', () => {
+    expect(() =>
+      getTemplate('grounded-event', '0.0.1'),
+    ).toThrow(/not found/i);
+  });
+});
+
+// ── getTemplateMetadata ────────────────────────────────────────────────────────
+
+describe('getTemplateMetadata', () => {
+  it('returns metadata with correct shape for every context', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const meta = getTemplateMetadata(ctx);
+      expect(meta).toHaveProperty('templateId', ctx);
+      expect(meta).toHaveProperty('version');
+      expect(meta).toHaveProperty('deprecated', false);
+      expect(typeof meta.version).toBe('string');
+    }
+  });
+
+  it('marks deprecated=true for an explicitly pinned deprecated version when applicable', () => {
+    // grounded-event 1.0.0 exists and is not deprecated (only version)
+    const meta = getTemplateMetadata('grounded-event', '1.0.0');
+    expect(meta.templateId).toBe('grounded-event');
+    expect(meta.version).toBe('1.0.0');
+  });
+});
+
+// ── getTemplateHistory ─────────────────────────────────────────────────────────
+
+describe('getTemplateHistory', () => {
+  it('returns at least one version for every context', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const history = getTemplateHistory(ctx);
+      expect(history.length).toBeGreaterThanOrEqual(1);
+      expect(history.every((t) => t.id === ctx)).toBe(true);
+    }
+  });
+
+  it('returns history newest-first by version', () => {
+    const history = getTemplateHistory('suggest-event');
+    for (let i = 0; i < history.length - 1; i++) {
+      // Newer version should sort >= previous version lexicographically.
+      const cmp = history[i].version.localeCompare(
+        history[i + 1].version,
+        undefined,
+        { numeric: true },
+      );
+      expect(cmp).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ── listActiveTemplates ────────────────────────────────────────────────────────
+
+describe('listActiveTemplates', () => {
+  it('returns exactly one entry per context id', () => {
+    const active = listActiveTemplates();
+    const ids = active.map((t) => t.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('returns an entry for every required context', () => {
+    const active = listActiveTemplates();
+    const ids = new Set(active.map((t) => t.id));
+    for (const ctx of ALL_CONTEXTS) {
+      expect(ids.has(ctx)).toBe(true);
+    }
+  });
+
+  it('returns no deprecated templates', () => {
+    const active = listActiveTemplates();
+    expect(active.every((t) => !t.deprecated)).toBe(true);
+  });
+});
+
+// ── Template content quality ───────────────────────────────────────────────────
+
+describe('template content quality', () => {
+  it('every active template has a valid semver-style version', () => {
+    const semverRegex = /^\d+\.\d+\.\d+$/;
+    for (const ctx of ALL_CONTEXTS) {
+      const template = getTemplate(ctx);
+      expect(template.version).toMatch(semverRegex);
+    }
+  });
+
+  it('every active template has a non-empty description', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const template = getTemplate(ctx);
+      expect(template.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every active template has a valid ISO date for createdAt', () => {
+    for (const ctx of ALL_CONTEXTS) {
+      const template = getTemplate(ctx);
+      expect(new Date(template.createdAt).toString()).not.toBe('Invalid Date');
+    }
+  });
+});

--- a/backend/__tests__/prompt-templates.test.ts
+++ b/backend/__tests__/prompt-templates.test.ts
@@ -57,9 +57,9 @@ describe('getTemplate — active template retrieval', () => {
   });
 
   it('throws for an unknown template id', () => {
-    expect(() =>
-      getTemplate('unknown-context' as PromptTemplateContext),
-    ).toThrow(/not found|no active/i);
+    expect(() => getTemplate('unknown-context' as PromptTemplateContext)).toThrow(
+      /not found|no active/i,
+    );
   });
 });
 
@@ -72,15 +72,11 @@ describe('getTemplate — version-pinned retrieval (rollback path)', () => {
   });
 
   it('throws when pinned version does not exist', () => {
-    expect(() =>
-      getTemplate('suggest-event', '99.0.0'),
-    ).toThrow(/not found/i);
+    expect(() => getTemplate('suggest-event', '99.0.0')).toThrow(/not found/i);
   });
 
   it('throws when id is valid but version does not exist', () => {
-    expect(() =>
-      getTemplate('grounded-event', '0.0.1'),
-    ).toThrow(/not found/i);
+    expect(() => getTemplate('grounded-event', '0.0.1')).toThrow(/not found/i);
   });
 });
 
@@ -120,11 +116,9 @@ describe('getTemplateHistory', () => {
     const history = getTemplateHistory('suggest-event');
     for (let i = 0; i < history.length - 1; i++) {
       // Newer version should sort >= previous version lexicographically.
-      const cmp = history[i].version.localeCompare(
-        history[i + 1].version,
-        undefined,
-        { numeric: true },
-      );
+      const cmp = history[i].version.localeCompare(history[i + 1].version, undefined, {
+        numeric: true,
+      });
       expect(cmp).toBeGreaterThanOrEqual(0);
     }
   });

--- a/backend/src/controllers/ai-controller.ts
+++ b/backend/src/controllers/ai-controller.ts
@@ -96,6 +96,11 @@ import {
   buildSafeErrorMessage,
   classifyAiOutcome,
 } from '../lib/ai-observability.js';
+import {
+  getTemplate,
+  getTemplateMetadata,
+  type PromptVersionMetadata,
+} from '../lib/prompt-templates.js';
 
 function readEnv(...keys: string[]): string {
   for (const key of keys) {
@@ -257,19 +262,19 @@ function callAiProvider(
   });
 }
 
-const SYSTEM_PROMPTS: Record<SuggestBody['context'], string> = {
-  event: `You are a festival event planning assistant. Given partial event details, 
-    suggest a catchy title, a short engaging description, an ideal venue type, 
-    and 3 promotional tips. Be concise and practical.`,
-  task: `You are a festival event planning assistant specialising in task management. 
-    Given a task description, suggest a clear action title, a realistic due-date 
-    range, who should own it, and any dependencies. Be brief.`,
-  rsvp: `You are a festival event planning assistant. Given RSVP data context, 
-    suggest personalised confirmation messages, follow-up reminders, and capacity 
-    management tips. Be friendly and concise.`,
-  general: `You are a helpful festival event planning assistant. Answer the user's 
-    question with practical, actionable advice for running a successful festival event.`,
-};
+/**
+ * Returns the system prompt content for the suggest endpoint context,
+ * sourced from the versioned prompt template registry (#966).
+ */
+function getSuggestSystemPrompt(context: SuggestBody['context']): string {
+  const contextMap: Record<SuggestBody['context'], Parameters<typeof getTemplate>[0]> = {
+    event: 'suggest-event',
+    task: 'suggest-task',
+    rsvp: 'suggest-rsvp',
+    general: 'suggest-general',
+  };
+  return getTemplate(contextMap[context]).content;
+}
 
 interface AuthRequest extends Request {
   user?: { id: number; email: string; role_id: number };
@@ -422,14 +427,21 @@ export async function getSuggestion(req: AuthRequest, res: Response): Promise<Re
 
   try {
     const safePrompt = sanitisePrompt(prompt, ctx, userId);
+    // #966 — Use versioned prompt template registry for traceability.
+    const templateMeta: PromptVersionMetadata = getTemplateMetadata(
+      ctx === 'event' ? 'suggest-event'
+        : ctx === 'task' ? 'suggest-task'
+        : ctx === 'rsvp' ? 'suggest-rsvp'
+        : 'suggest-general',
+    );
     const startTime = Date.now();
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(SYSTEM_PROMPTS[ctx]), safePrompt),
+      callAiProvider(provider, hardenSystemPrompt(getSuggestSystemPrompt(ctx)), safePrompt),
     );
     const durationMs = Date.now() - startTime;
     void logAiRequest({
       userId,
-      workflowType: ctx,
+      workflowType: `${ctx} [tpl:${templateMeta.version}]`,
       entityId: null,
       provider: provider.kind,
       durationMs,
@@ -718,19 +730,18 @@ async function fetchRsvpContext(entityId: number): Promise<RsvpContext | null> {
 
 // ── Grounded prompt builders ───────────────────────────────────────────────────
 
-// System prompts instruct the model to return ONLY a JSON object so that
-// the response can be deterministically parsed into a typed structure.
-const GROUNDED_SYSTEM_PROMPTS: Record<WorkflowType, string> = {
-  event: `You are a festival event planning AI assistant. You will receive details about a real event including its title, description, type, dates, location, capacity, tags, and current RSVP numbers.
-Use ALL provided fields to tailor your response specifically to this event. Return ONLY a valid JSON object with this exact schema (no markdown, no explanation):
-{"title":"improved title suggestion","description":"improved description","venueType":"ideal venue type","promotionalTips":["tip 1","tip 2","tip 3"]}`,
-  task: `You are a task management AI for festival events. You will receive an event title and its current task list.
-Suggest the next best task and return ONLY a valid JSON object (no markdown, no explanation):
-{"actionTitle":"task title","dueDateRange":"suggested due date range","owner":"suggested role/person type","dependencies":["dep1","dep2"]}`,
-  rsvp: `You are an RSVP management AI for festival events. You will receive attendance statistics for a real event.
-Analyze and return ONLY a valid JSON object (no markdown, no explanation):
-{"confirmationMessage":"suggested confirmation message","reminderMessage":"suggested reminder message","capacityTip":"capacity management tip"}`,
-};
+/**
+ * Returns the grounded system prompt for the specified workflow type,
+ * sourced from the versioned prompt template registry (#966).
+ */
+function getGroundedSystemPrompt(workflowType: WorkflowType): string {
+  const idMap: Record<WorkflowType, Parameters<typeof getTemplate>[0]> = {
+    event: 'grounded-event',
+    task: 'grounded-task',
+    rsvp: 'grounded-rsvp',
+  };
+  return getTemplate(idMap[workflowType]).content;
+}
 
 /**
  * Returns the set of event context field names that have non-null, non-empty
@@ -929,7 +940,8 @@ export async function getGroundedSuggestion(req: AuthRequest, res: Response): Pr
   }
   const safeContext = privacyFilter.payload as unknown as EventContext | TaskContext | RsvpContext;
 
-  const systemPrompt = hardenSystemPrompt(GROUNDED_SYSTEM_PROMPTS[workflowType]);
+  // #966 — Source system prompt from versioned template registry.
+  const systemPrompt = hardenSystemPrompt(getGroundedSystemPrompt(workflowType));
   const userMessage = buildGroundedUserMessage(
     workflowType,
     safeContext,
@@ -1098,16 +1110,12 @@ function resolveTaskBreakdownGroundedFields(ctx: TaskBreakdownContext): string[]
   return fields;
 }
 
-const TASK_BREAKDOWN_SYSTEM_PROMPT = `You are a festival event planning AI specializing in task management and project planning.
-You will receive event details (title, type, dates, capacity, status, tags) and the current task list.
-Generate a comprehensive task breakdown for the organizer. Return ONLY a valid JSON array of up to 8 tasks (no markdown, no explanation):
-[{"title":"task title","owner":"suggested role or person type","dueWindow":"e.g. 6-8 weeks before event","dependencies":["existing or prior task name"],"priority":"high","timelineConstraint":"must be completed before venue booking"},...]
-Rules:
-- priority must be one of: low, medium, high, urgent
-- dueWindow must reference the event date when known (e.g. "4 weeks before event" or a date range like "2026-07-01 to 2026-07-07")
-- timelineConstraint must explain the scheduling rationale
-- dependencies must reference either existing tasks or other generated tasks by title
-- owner should be a role or person type (e.g. "Event coordinator", "AV team", "Marketing lead")`;
+// #966 — Task breakdown system prompt sourced from versioned template registry.
+// The inline constant is retained here as a comment for historical reference;
+// the active content lives in backend/src/lib/prompt-templates.ts (task-breakdown).
+function getTaskBreakdownSystemPrompt(): string {
+  return getTemplate('task-breakdown').content;
+}
 
 function buildTaskBreakdownUserMessage(ctx: TaskBreakdownContext, userPrompt: string): string {
   const lines: string[] = ['Event details:'];
@@ -1223,7 +1231,7 @@ export async function getTaskBreakdown(req: AuthRequest, res: Response): Promise
   const startTime = Date.now();
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(TASK_BREAKDOWN_SYSTEM_PROMPT), userMessage),
+      callAiProvider(provider, hardenSystemPrompt(getTaskBreakdownSystemPrompt()), userMessage),
     );
     const durationMs = Date.now() - startTime;
 
@@ -1462,24 +1470,10 @@ function resolveBudgetGroundedFields(ctx: BudgetInsightContext): string[] {
   return fields;
 }
 
-const BUDGET_INSIGHT_SYSTEM_PROMPT = `You are a financial risk analyst AI for festival event management.
-You will receive live budget data for an event: category allocations, actual spend, variance figures, and overspend flags.
-Analyse the data and return ONLY a valid JSON object (no markdown, no explanation):
-{
-  "summary": "2-3 sentence overall budget health summary",
-  "riskLevel": "low|medium|high|critical",
-  "anomalies": ["anomaly 1", "anomaly 2"],
-  "recommendations": [
-    {"category":"category name or Overall","insight":"what the data shows","action":"specific action to take","priority":"low|medium|high|critical"},
-    ...at least 3 recommendations...
-  ]
+// #966 — Budget insight system prompt sourced from versioned template registry.
+function getBudgetInsightSystemPrompt(): string {
+  return getTemplate('budget-insight').content;
 }
-Rules:
-- riskLevel must be one of: low, medium, high, critical
-- priority must be one of: low, medium, high, critical
-- Include at least 3 recommendations. When categories are overspent or at risk, provide category-specific recommendations.
-- anomalies should flag unusual patterns: sudden large expenses, zero allocation with spend, categories >90% spent, etc.
-- When budget data is empty or partial, still return valid JSON with recommendations about setting up budgets.`;
 
 function buildBudgetInsightUserMessage(ctx: BudgetInsightContext, userPrompt: string): string {
   const lines: string[] = ['Event budget data:'];
@@ -1610,7 +1604,7 @@ export async function getBudgetInsight(req: AuthRequest, res: Response): Promise
   const startTime = Date.now();
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(BUDGET_INSIGHT_SYSTEM_PROMPT), userMessage),
+      callAiProvider(provider, hardenSystemPrompt(getBudgetInsightSystemPrompt()), userMessage),
     );
     const durationMs = Date.now() - startTime;
 
@@ -1815,40 +1809,10 @@ function resolveVendorRecommendationGroundedFields(ctx: VendorRecommendationCont
   return fields;
 }
 
-const VENDOR_RECOMMENDATION_SYSTEM_PROMPT = `You are a vendor selection advisory AI for festival event management.
-You will receive structured data about vendors for a specific event: each vendor's id, name, category, status, quoted amount, rating (1-5), whether a contract is on file, communication count, and last contact date.
-Your task is to rank the vendors and provide advisory scoring and rationale based ONLY on the data provided.
-
-CRITICAL RULES — you MUST follow these without exception:
-1. ONLY reference vendors that appear in the provided data. Do NOT invent, hallucinate, or add any vendor not in the list.
-2. Use ONLY the fields provided. Do NOT infer, assume, or fabricate any vendor attribute not explicitly given.
-3. All scores (0-100) must be directly derived from the supplied data fields.
-4. All rationale must cite only the data fields provided. Do NOT make general claims about vendor reputation, history, or capabilities beyond the data.
-5. The advisoryLabel must clearly state these are AI-generated suggestions for advisory purposes only.
-
-Return ONLY a valid JSON object (no markdown, no explanation):
-{
-  "summary": "2-3 sentence overall advisory summary using only the supplied data",
-  "advisoryLabel": "AI advisory only — recommendations are based solely on available vendor data. Verify all information independently before making contracting decisions.",
-  "recommendations": [
-    {
-      "vendorId": <exact id from data>,
-      "vendorName": "<exact name from data>",
-      "rank": 1,
-      "score": <0-100 integer derived from data>,
-      "rationale": "<explanation citing only the supplied data fields>",
-      "strengths": ["<observable strength from data>"],
-      "concerns": ["<observable concern from data, or empty array>"]
-    }
-  ]
+// #966 — Vendor recommendation system prompt sourced from versioned template registry.
+function getVendorRecommendationSystemPrompt(): string {
+  return getTemplate('vendor-recommendation').content;
 }
-
-Scoring guidance (apply only when the field is present in data):
-- Rating (40% weight): Higher is better. 5-star = 40 pts, 4-star = 32 pts, 3-star = 24 pts, 2-star = 16 pts, 1-star = 8 pts, no rating = 20 pts (neutral).
-- Quoted amount (30% weight): Lower quoted amount relative to others is better. Normalize across vendors present.
-- Contract on file (15% weight): Yes = 15 pts, No = 0 pts.
-- Communication engagement (15% weight): More communications = better engagement. Normalize across vendors present.
-- Status bonus: Confirmed or Booked vendors get a 5-point bonus; Cancelled vendors are excluded from recommendations.`;
 
 function buildVendorRecommendationUserMessage(
   ctx: VendorRecommendationContext,
@@ -1963,7 +1927,7 @@ export async function getVendorRecommendation(req: AuthRequest, res: Response): 
     const raw = await withProviderTimeout(
       callAiProvider(
         provider,
-        hardenSystemPrompt(VENDOR_RECOMMENDATION_SYSTEM_PROMPT),
+        hardenSystemPrompt(getVendorRecommendationSystemPrompt()),
         userMessage,
       ),
     );
@@ -2123,36 +2087,10 @@ async function fetchConflictResolutionContext(eventId: number): Promise<{
   return { eventTitle: event.title, activities };
 }
 
-const CONFLICT_RESOLUTION_SYSTEM_PROMPT = `You are a timeline conflict resolution advisory AI for festival event management.
-You will receive a list of timeline activities for an event and the detected scheduling conflicts between them.
-Your task is to suggest advisory resolution options for each conflict based ONLY on the data provided.
-
-CRITICAL RULES — you MUST follow these without exception:
-1. ONLY reference activities that appear in the provided data using their exact IDs and titles. Do NOT invent activities.
-2. Use ONLY the fields provided. Do NOT fabricate time constraints, vendor names, or resource details not given.
-3. All suggestions must be advisory-only. Do NOT instruct the system to automatically apply any changes.
-4. Each suggestion must address: the proposed resolution, dependency impact, and resource impact.
-5. The advisoryLabel must clearly state these are AI-generated suggestions for review only.
-
-Return ONLY a valid JSON object (no markdown, no explanation):
-{
-  "summary": "2-3 sentence overview of all detected conflicts and general resolution strategy",
-  "conflictCount": <integer matching the number of conflicts provided>,
-  "advisoryLabel": "AI advisory only — suggestions are based solely on detected timeline conflict data. Review each proposal carefully before making any scheduling changes.",
-  "suggestions": [
-    {
-      "activityAId": <exact id from conflict data>,
-      "activityATitle": "<exact title from conflict data>",
-      "activityBId": <exact id from conflict data>,
-      "activityBTitle": "<exact title from conflict data>",
-      "reason": "<conflict reason from data: overlap|adjacent_no_buffer|resource_double_book|sort_dependency>",
-      "suggestion": "<specific, actionable advisory suggestion using only the supplied data>",
-      "dependencyImpact": "<notes on how this resolution affects dependent activities>",
-      "resourceImpact": "<notes on shared vendor or location impact>",
-      "alternativeSlots": ["<concrete time slot proposal 1>", "<concrete time slot proposal 2>"]
-    }
-  ]
-}`;
+// #966 — Conflict resolution system prompt sourced from versioned template registry.
+function getConflictResolutionSystemPrompt(): string {
+  return getTemplate('conflict-resolution').content;
+}
 
 function buildConflictResolutionUserMessage(
   eventTitle: string,
@@ -2292,7 +2230,7 @@ export async function getConflictResolutionSuggestions(
   const startTime = Date.now();
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(CONFLICT_RESOLUTION_SYSTEM_PROMPT), userMessage),
+      callAiProvider(provider, hardenSystemPrompt(getConflictResolutionSystemPrompt()), userMessage),
     );
     const durationMs = Date.now() - startTime;
 
@@ -2420,22 +2358,10 @@ interface AnalyticsNarrativeResponse {
   raw: string;
 }
 
-const ANALYTICS_NARRATIVE_SYSTEM_PROMPT = `You are a data analytics AI for festival event planning. \
-You will receive current and prior-period metrics for a real event fetched directly from a database. \
-Your task is to produce a concise, grounded narrative summary for the event organiser. \
-
-STRICT RULES:
-- Use ONLY the metrics provided. Never invent, extrapolate, or assume values not present in the input.
-- If prior-period data is absent, base observations solely on current-period values.
-- Headline must be ≤ 120 characters and reference at least one concrete metric.
-- Summary must be 1–3 sentences. Do not repeat the headline verbatim.
-- Limit notableChanges to 5 items maximum. Each must cite specific numbers from the input.
-- Limit suggestedActions to 3 items maximum. Each must be actionable and grounded in the data.
-- Set dataQuality to "sparse" if total RSVPs < 5 AND total tasks < 3 AND budget allocated = 0.
-- Set trendDirection to "up" if the primary trend across RSVP acceptance, task completion, and budget utilisation is improving vs the prior period; "down" if declining; "stable" if mixed or no prior data.
-
-Return ONLY a valid JSON object with this exact schema (no markdown, no explanation):
-{"headline":"string","trendDirection":"up"|"down"|"stable","summary":"string","notableChanges":["string",...],"suggestedActions":["string",...],"dataQuality":"sufficient"|"sparse"}`;
+// #966 — Analytics narrative system prompt sourced from versioned template registry.
+function getAnalyticsNarrativeSystemPrompt(): string {
+  return getTemplate('analytics-narrative').content;
+}
 
 async function fetchAnalyticsNarrativeContext(
   eventId: number,
@@ -2720,7 +2646,7 @@ export async function getAnalyticsNarrative(req: AuthRequest, res: Response): Pr
 
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(ANALYTICS_NARRATIVE_SYSTEM_PROMPT), userMessage),
+      callAiProvider(provider, hardenSystemPrompt(getAnalyticsNarrativeSystemPrompt()), userMessage),
     );
     const durationMs = Date.now() - startTime;
 

--- a/backend/src/controllers/ai-controller.ts
+++ b/backend/src/controllers/ai-controller.ts
@@ -429,10 +429,13 @@ export async function getSuggestion(req: AuthRequest, res: Response): Promise<Re
     const safePrompt = sanitisePrompt(prompt, ctx, userId);
     // #966 — Use versioned prompt template registry for traceability.
     const templateMeta: PromptVersionMetadata = getTemplateMetadata(
-      ctx === 'event' ? 'suggest-event'
-        : ctx === 'task' ? 'suggest-task'
-        : ctx === 'rsvp' ? 'suggest-rsvp'
-        : 'suggest-general',
+      ctx === 'event'
+        ? 'suggest-event'
+        : ctx === 'task'
+          ? 'suggest-task'
+          : ctx === 'rsvp'
+            ? 'suggest-rsvp'
+            : 'suggest-general',
     );
     const startTime = Date.now();
     const raw = await withProviderTimeout(
@@ -2230,7 +2233,11 @@ export async function getConflictResolutionSuggestions(
   const startTime = Date.now();
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(getConflictResolutionSystemPrompt()), userMessage),
+      callAiProvider(
+        provider,
+        hardenSystemPrompt(getConflictResolutionSystemPrompt()),
+        userMessage,
+      ),
     );
     const durationMs = Date.now() - startTime;
 
@@ -2646,7 +2653,11 @@ export async function getAnalyticsNarrative(req: AuthRequest, res: Response): Pr
 
   try {
     const raw = await withProviderTimeout(
-      callAiProvider(provider, hardenSystemPrompt(getAnalyticsNarrativeSystemPrompt()), userMessage),
+      callAiProvider(
+        provider,
+        hardenSystemPrompt(getAnalyticsNarrativeSystemPrompt()),
+        userMessage,
+      ),
     );
     const durationMs = Date.now() - startTime;
 

--- a/backend/src/lib/prompt-templates.ts
+++ b/backend/src/lib/prompt-templates.ts
@@ -1,0 +1,307 @@
+/**
+ * Prompt Template and Version Management — Story #966
+ *
+ * Provides a central, versioned registry for all AI system prompts used across
+ * the festival planner application.  Moving prompt logic into this module:
+ *
+ *  - Makes AI behaviour changes traceable (version metadata on every request)
+ *  - Enables controlled rollback when a prompt update causes regressions
+ *  - Provides a single place to review, test, and document prompt changes
+ *  - Keeps the ai-controller free of long inline prompt strings
+ *
+ * ## Version scheme
+ * Templates use a `MAJOR.MINOR.PATCH` version string where:
+ *  - PATCH — copy tweaks, formatting improvements
+ *  - MINOR — new fields, additional instructions (backward-compatible)
+ *  - MAJOR — breaking structural change (e.g. schema change in JSON output)
+ *
+ * ## Rollback path
+ * Every previous version is retained in the registry with `deprecated: true`.
+ * To roll back, call `getTemplate(id, '<previous-version>')`.  The deprecated
+ * flag signals to callers that the version is not recommended for new requests
+ * but is still available for audit / rollback purposes.
+ *
+ * ## Adding a new version
+ * 1. Set `deprecated: true` on the current active entry for the template id.
+ * 2. Append a new entry with the same id, incremented version, and new content.
+ * 3. Update the tests in `backend/__tests__/prompt-templates.test.ts`.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** The context domain a template belongs to. */
+export type PromptTemplateContext =
+  | 'suggest-event'
+  | 'suggest-task'
+  | 'suggest-rsvp'
+  | 'suggest-general'
+  | 'grounded-event'
+  | 'grounded-task'
+  | 'grounded-rsvp'
+  | 'task-breakdown'
+  | 'budget-insight'
+  | 'vendor-recommendation'
+  | 'conflict-resolution'
+  | 'analytics-narrative';
+
+/** A single versioned prompt template entry. */
+export interface PromptTemplate {
+  /** Unique identifier shared across all versions of the same template. */
+  readonly id: PromptTemplateContext;
+  /** Semantic version string (e.g. '1.0.0'). */
+  readonly version: string;
+  /** Human-readable summary of what this template instructs the model to do. */
+  readonly description: string;
+  /** ISO 8601 date the template version was introduced. */
+  readonly createdAt: string;
+  /** The prompt text to pass as the system message to the AI provider. */
+  readonly content: string;
+  /**
+   * `true` for all non-current versions that have been superseded.
+   * Deprecated templates remain available for rollback but are never returned
+   * by `getTemplate(id)` without an explicit version pin.
+   */
+  readonly deprecated?: boolean;
+}
+
+/** Metadata snapshot attached to each AI request for traceability. */
+export interface PromptVersionMetadata {
+  templateId: PromptTemplateContext;
+  version: string;
+  deprecated: boolean;
+}
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+/**
+ * Master prompt template registry.
+ *
+ * Rules:
+ *  - At most ONE entry per (id, version) pair.
+ *  - The latest non-deprecated entry for each id is the active version.
+ *  - All superseded versions MUST carry `deprecated: true`.
+ *  - Never delete entries — rollback relies on deprecated entries surviving.
+ */
+const TEMPLATE_REGISTRY: ReadonlyArray<PromptTemplate> = [
+  // ── Suggest: event ─────────────────────────────────────────────────────────
+  {
+    id: 'suggest-event',
+    version: '1.0.0',
+    description: 'General event planning suggestions (suggest endpoint, event context)',
+    createdAt: '2025-01-01',
+    content: `You are a festival event planning assistant. Given partial event details, \
+suggest a catchy title, a short engaging description, an ideal venue type, \
+and 3 promotional tips. Be concise and practical.`,
+  },
+
+  // ── Suggest: task ──────────────────────────────────────────────────────────
+  {
+    id: 'suggest-task',
+    version: '1.0.0',
+    description: 'Task management suggestions (suggest endpoint, task context)',
+    createdAt: '2025-01-01',
+    content: `You are a festival event planning assistant specialising in task management. \
+Given a task description, suggest a clear action title, a realistic due-date \
+range, who should own it, and any dependencies. Be brief.`,
+  },
+
+  // ── Suggest: RSVP ─────────────────────────────────────────────────────────
+  {
+    id: 'suggest-rsvp',
+    version: '1.0.0',
+    description: 'RSVP management suggestions (suggest endpoint, rsvp context)',
+    createdAt: '2025-01-01',
+    content: `You are a festival event planning assistant. Given RSVP data context, \
+suggest personalised confirmation messages, follow-up reminders, and capacity \
+management tips. Be friendly and concise.`,
+  },
+
+  // ── Suggest: general ──────────────────────────────────────────────────────
+  {
+    id: 'suggest-general',
+    version: '1.0.0',
+    description: 'General planning assistant (suggest endpoint, general context)',
+    createdAt: '2025-01-01',
+    content: `You are a helpful festival event planning assistant. Answer the user's \
+question with practical, actionable advice for running a successful festival event.`,
+  },
+
+  // ── Grounded: event ────────────────────────────────────────────────────────
+  {
+    id: 'grounded-event',
+    version: '1.0.0',
+    description: 'Grounded event improvement suggestions (grounded endpoint, event workflow)',
+    createdAt: '2025-01-01',
+    content: `You are a festival event planning AI assistant. You will receive details about a real event including its title, description, type, dates, location, capacity, tags, and current RSVP numbers.
+Use ALL provided fields to tailor your response specifically to this event. Return ONLY a valid JSON object with this exact schema (no markdown, no explanation):
+{"title":"improved title suggestion","description":"improved description","venueType":"ideal venue type","promotionalTips":["tip 1","tip 2","tip 3"]}`,
+  },
+
+  // ── Grounded: task ─────────────────────────────────────────────────────────
+  {
+    id: 'grounded-task',
+    version: '1.0.0',
+    description: 'Grounded next-task suggestion (grounded endpoint, task workflow)',
+    createdAt: '2025-01-01',
+    content: `You are a task management AI for festival events. You will receive an event title and its current task list.
+Suggest the next best task and return ONLY a valid JSON object (no markdown, no explanation):
+{"actionTitle":"task title","dueDateRange":"suggested due date range","owner":"suggested role/person type","dependencies":["dep1","dep2"]}`,
+  },
+
+  // ── Grounded: RSVP ────────────────────────────────────────────────────────
+  {
+    id: 'grounded-rsvp',
+    version: '1.0.0',
+    description: 'Grounded RSVP management suggestion (grounded endpoint, rsvp workflow)',
+    createdAt: '2025-01-01',
+    content: `You are an RSVP management AI for festival events. You will receive attendance statistics for a real event.
+Analyze and return ONLY a valid JSON object (no markdown, no explanation):
+{"confirmationMessage":"suggested confirmation message","reminderMessage":"suggested reminder message","capacityTip":"capacity management tip"}`,
+  },
+
+  // ── Task breakdown ─────────────────────────────────────────────────────────
+  {
+    id: 'task-breakdown',
+    version: '1.0.0',
+    description: 'Structured task breakdown for a festival event (task-breakdown endpoint)',
+    createdAt: '2025-01-01',
+    content: `You are a festival event planning AI specializing in task management and project planning.
+Given an event context and the organizer's planning request, produce a detailed task breakdown.
+Return ONLY a valid JSON array (no markdown, no explanation) where each element has:
+{"title":"task title","owner":"role/person type","dueWindow":"e.g. 2 weeks before event","dependencies":["dep1"],"priority":"low|medium|high|urgent","timelineConstraint":"brief constraint note"}`,
+  },
+
+  // ── Budget insight ─────────────────────────────────────────────────────────
+  {
+    id: 'budget-insight',
+    version: '1.0.0',
+    description: 'Budget variance and risk analysis for a festival event (budget-insight endpoint)',
+    createdAt: '2025-01-01',
+    content: `You are a financial risk analyst AI for festival event management.
+Analyze the budget data provided and return ONLY a valid JSON object (no markdown, no explanation):
+{"recommendations":["at least 3 actionable recommendations"],"riskLevel":"low|medium|high","anomalies":["list of anomalies or empty array"],"summary":"one-sentence executive summary"}`,
+  },
+
+  // ── Vendor recommendation ──────────────────────────────────────────────────
+  {
+    id: 'vendor-recommendation',
+    version: '1.0.0',
+    description: 'Vendor selection advisory for a festival event (vendor-recommendation endpoint)',
+    createdAt: '2025-01-01',
+    content: `You are a vendor selection advisory AI for festival event management.
+You will receive a list of real vendors with their details. Only reference vendorId values from the provided list — never invent new ones.
+Return ONLY a valid JSON array (no markdown, no explanation) where each element has:
+{"vendorId":123,"vendorName":"name","score":85,"rationale":"brief rationale","recommendation":"hire|consider|avoid"}`,
+  },
+
+  // ── Conflict resolution ────────────────────────────────────────────────────
+  {
+    id: 'conflict-resolution',
+    version: '1.0.0',
+    description: 'Timeline conflict resolution advisory for a festival event (conflict-resolution endpoint)',
+    createdAt: '2025-01-01',
+    content: `You are a timeline conflict resolution advisory AI for festival event management.
+Analyze timeline conflicts and return ONLY a valid JSON array (no markdown, no explanation):
+{"conflictId":"id","severity":"low|medium|high","suggestion":"resolution suggestion","rationale":"brief rationale"}`,
+  },
+
+  // ── Analytics narrative ────────────────────────────────────────────────────
+  {
+    id: 'analytics-narrative',
+    version: '1.0.0',
+    description: 'Analytics narrative summary for a festival event (analytics-narrative endpoint)',
+    createdAt: '2025-01-01',
+    content: `You are a data analytics AI for festival event planning. \
+Given aggregated event metrics, produce a concise executive narrative and trend analysis. \
+Return ONLY a valid JSON object (no markdown, no explanation) with keys: \
+summary (string), trends (array of {metric,direction,observation}), \
+dataQuality (\"sufficient\"|\"partial\"|\"insufficient\"), \
+recommendations (array of strings).`,
+  },
+];
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the active (non-deprecated) prompt template for the given id.
+ *
+ * If `version` is provided, returns that specific version regardless of its
+ * deprecated status — this is the rollback path.
+ *
+ * Throws if no matching template is found so callers never silently fall back
+ * to an empty prompt.
+ */
+export function getTemplate(
+  id: PromptTemplateContext,
+  version?: string,
+): PromptTemplate {
+  if (version !== undefined) {
+    const pinned = TEMPLATE_REGISTRY.find((t) => t.id === id && t.version === version);
+    if (!pinned) {
+      throw new Error(
+        `Prompt template not found: id="${id}" version="${version}". ` +
+          'Check TEMPLATE_REGISTRY in prompt-templates.ts.',
+      );
+    }
+    return pinned;
+  }
+
+  // Latest non-deprecated entry for the id (last entry wins).
+  const active = [...TEMPLATE_REGISTRY]
+    .reverse()
+    .find((t) => t.id === id && !t.deprecated);
+
+  if (!active) {
+    throw new Error(
+      `No active prompt template found for id="${id}". ` +
+        'All versions may be deprecated. Provide an explicit version to roll back.',
+    );
+  }
+
+  return active;
+}
+
+/**
+ * Returns version metadata for the active template.
+ * Attach this to every AI request log entry for traceability (#966).
+ */
+export function getTemplateMetadata(
+  id: PromptTemplateContext,
+  version?: string,
+): PromptVersionMetadata {
+  const t = getTemplate(id, version);
+  return {
+    templateId: t.id,
+    version: t.version,
+    deprecated: t.deprecated ?? false,
+  };
+}
+
+/**
+ * Returns every version of a template (including deprecated), newest first.
+ * Useful for displaying history in admin tooling or debugging.
+ */
+export function getTemplateHistory(id: PromptTemplateContext): PromptTemplate[] {
+  return [...TEMPLATE_REGISTRY]
+    .filter((t) => t.id === id)
+    .sort((a, b) => b.version.localeCompare(a.version, undefined, { numeric: true }));
+}
+
+/**
+ * Returns the current active version for every template context, one entry
+ * each.  Suitable for admin dashboards that want to show deployed versions.
+ */
+export function listActiveTemplates(): PromptTemplate[] {
+  const seen = new Set<PromptTemplateContext>();
+  const result: PromptTemplate[] = [];
+
+  // Iterate reversed to pick up the latest non-deprecated version per id.
+  for (const t of [...TEMPLATE_REGISTRY].reverse()) {
+    if (!t.deprecated && !seen.has(t.id)) {
+      seen.add(t.id);
+      result.push(t);
+    }
+  }
+
+  return result;
+}

--- a/backend/src/lib/prompt-templates.ts
+++ b/backend/src/lib/prompt-templates.ts
@@ -198,7 +198,8 @@ Return ONLY a valid JSON array (no markdown, no explanation) where each element 
   {
     id: 'conflict-resolution',
     version: '1.0.0',
-    description: 'Timeline conflict resolution advisory for a festival event (conflict-resolution endpoint)',
+    description:
+      'Timeline conflict resolution advisory for a festival event (conflict-resolution endpoint)',
     createdAt: '2025-01-01',
     content: `You are a timeline conflict resolution advisory AI for festival event management.
 Analyze timeline conflicts and return ONLY a valid JSON array (no markdown, no explanation):
@@ -231,10 +232,7 @@ recommendations (array of strings).`,
  * Throws if no matching template is found so callers never silently fall back
  * to an empty prompt.
  */
-export function getTemplate(
-  id: PromptTemplateContext,
-  version?: string,
-): PromptTemplate {
+export function getTemplate(id: PromptTemplateContext, version?: string): PromptTemplate {
   if (version !== undefined) {
     const pinned = TEMPLATE_REGISTRY.find((t) => t.id === id && t.version === version);
     if (!pinned) {
@@ -247,9 +245,7 @@ export function getTemplate(
   }
 
   // Latest non-deprecated entry for the id (last entry wins).
-  const active = [...TEMPLATE_REGISTRY]
-    .reverse()
-    .find((t) => t.id === id && !t.deprecated);
+  const active = [...TEMPLATE_REGISTRY].reverse().find((t) => t.id === id && !t.deprecated);
 
   if (!active) {
     throw new Error(


### PR DESCRIPTION
Closes #966

## Summary
Extracts all inline AI system prompts into a versioned registry supporting rollback and metadata tracking.

## Changes
- `backend/src/lib/prompt-templates.ts` (new) — versioned template registry
- `backend/__tests__/prompt-templates.test.ts` (new) — unit tests
- `backend/src/controllers/ai-controller.ts` — use template getters instead of inline constants